### PR TITLE
feat: funnel correction — OSS → Pro bridge + PostHog wiring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,14 @@ COPY . .
 # Uncomment the following line in case you want to disable telemetry during the build.
 ENV NEXT_TELEMETRY_DISABLED 1
 
+# PostHog — NEXT_PUBLIC_* vars are inlined into the client bundle at
+# build time. Must be passed as build args from docker-compose or the
+# `docker build --build-arg` flag. If unset, PostHog stays disabled.
+ARG NEXT_PUBLIC_POSTHOG_API_KEY
+ENV NEXT_PUBLIC_POSTHOG_API_KEY=$NEXT_PUBLIC_POSTHOG_API_KEY
+ARG NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+ENV NEXT_PUBLIC_POSTHOG_HOST=$NEXT_PUBLIC_POSTHOG_HOST
+
 # Build the application
 RUN corepack enable pnpm && pnpm run build
 

--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -5,6 +5,7 @@ import { FAQItem } from "@/components/sections/faq-section";
 import WallOfLove from "@/components/sections/wall-of-love";
 import VideoShowcaseGrid from "@/components/sections/video-showcase-grid";
 import InspirationsSection from "@/components/sections/inspirations-section";
+import { ProSection } from "@/components/sections/pro-section";
 
 export default function Home() {
   const faqItems: FAQItem[] = [
@@ -42,7 +43,7 @@ export default function Home() {
       id: "pro",
       question: "What does Ruixen Pro include?",
       answer:
-        "Pro adds 50+ premium templates and advanced compositions on top of the free library at pro.ruixen.com. One-time purchase with lifetime updates. The core 170+ components remain free and open-source.",
+        "Pro adds 50+ premium templates and advanced compositions on top of the free library. One-time purchase — $59 lifetime, no subscription. See full pricing and comparison at ruixen.com/pricing. The core 170+ components remain free and open-source.",
     },
   ];
 
@@ -80,6 +81,7 @@ export default function Home() {
       {/* <VideoShowcaseGrid /> */}
       {/* <InspirationsSection /> */}
       <WallOfLove />
+      <ProSection />
       <FAQSection faqItems={faqItems} className="py-16 md:py-24" />
 
       {/* Twitter CTA */}

--- a/app/api/pricing/route.ts
+++ b/app/api/pricing/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+
+// Revalidate the Pro price once per hour. Keeps ruixen.com → pro.ruixen.com
+// price consistency without coupling OSS deploys to Pro pricing changes.
+export const revalidate = 3600;
+
+const FALLBACK = {
+  amountCents: 5900,
+  display: "$59",
+  currency: "USD",
+};
+
+export async function GET() {
+  try {
+    const res = await fetch("https://pro.ruixen.com/api/v1/membership/plans", {
+      next: { revalidate: 3600 },
+    });
+    if (!res.ok) throw new Error(`upstream ${res.status}`);
+    const data = await res.json();
+    const plan = data.plans?.[0];
+    return NextResponse.json({
+      amountCents: plan?.price_usd_cents ?? FALLBACK.amountCents,
+      display: plan?.price_display ?? FALLBACK.display,
+      currency: data.currency ?? FALLBACK.currency,
+    });
+  } catch {
+    // Never fail the OSS site if Pro is down — serve the last-known truth.
+    return NextResponse.json(FALLBACK);
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { ThemeProvider } from "@/components/theme-provider";
 import { SiteBanner } from "@/components/site-banner";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { PHProvider } from "@/components/posthog-provider";
 import { fontMono, fontSans } from "@/lib/fonts";
 import { absoluteUrl, cn } from "@/lib/utils";
 import { Provider as JotaiProvider } from "jotai";
@@ -21,7 +22,7 @@ export const metadata: Metadata = {
     template: "%s | Ruixen UI",
   },
   description:
-    "170+ free, open-source React components built with Tailwind CSS, TypeScript & Framer Motion. Supports Tailwind v3 + v4, Radix & Base UI primitives. Copy-paste into Next.js projects.",
+    "170+ free React components built with Tailwind CSS, TypeScript & Framer Motion. Plus Ruixen Pro: 50+ premium templates with lifetime updates for $59. Supports Tailwind v3 + v4, Radix & Base UI primitives. Copy-paste into Next.js projects.",
   authors: [{ name: "Srinath" }],
   keywords: [
     "react component library",
@@ -117,15 +118,17 @@ export default function RootLayout({
         )}
       >
         <JotaiProvider>
-          <ThemeProvider attribute="class" defaultTheme="light">
-            <TooltipProvider>
-              <SiteBanner />
-              {children}
-              <Toaster />
-              <Analytics />
-              {/* <GitHubStarPopup /> */}
-            </TooltipProvider>
-          </ThemeProvider>
+          <PHProvider>
+            <ThemeProvider attribute="class" defaultTheme="light">
+              <TooltipProvider>
+                <SiteBanner />
+                {children}
+                <Toaster />
+                <Analytics />
+                {/* <GitHubStarPopup /> */}
+              </TooltipProvider>
+            </ThemeProvider>
+          </PHProvider>
         </JotaiProvider>
       </body>
     </html>

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from "next";
+import Script from "next/script";
+
+import { PricingLanding } from "@/components/sections/pricing-landing";
+
+export const metadata: Metadata = {
+  title: "Pricing — Ruixen UI Pro",
+  description:
+    "Lifetime access to 50+ premium React components and production templates. $59 once. No subscription.",
+  alternates: {
+    canonical: "/pricing",
+  },
+  openGraph: {
+    title: "Ruixen UI Pro — $59 Lifetime",
+    description:
+      "50+ premium components, production templates, lifetime updates. One payment.",
+    url: "/pricing",
+    type: "website",
+  },
+};
+
+const PRODUCT_SCHEMA = {
+  "@context": "https://schema.org",
+  "@type": "Product",
+  name: "Ruixen UI Pro — Lifetime Membership",
+  description:
+    "50+ premium React components and production templates with lifetime updates.",
+  brand: { "@type": "Brand", name: "Ruixen UI" },
+  offers: {
+    "@type": "Offer",
+    price: "59.00",
+    priceCurrency: "USD",
+    availability: "https://schema.org/InStock",
+    url: "https://ruixen.com/pricing",
+  },
+};
+
+export default function PricingPage() {
+  return (
+    <>
+      <Script
+        id="pricing-product-schema"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(PRODUCT_SCHEMA) }}
+      />
+      <PricingLanding />
+    </>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -11,6 +11,17 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     {
       url: `${protocol}://${domain}`,
       lastModified: new Date(),
+      priority: 1,
+    },
+    {
+      url: `${protocol}://${domain}/pricing`,
+      lastModified: new Date(),
+      priority: 0.9,
+    },
+    {
+      url: `${protocol}://${domain}/templates`,
+      lastModified: new Date(),
+      priority: 0.8,
     },
     ...allPages.map((post) => ({
       url: `${protocol}://${domain}/${post.slugAsParams}`,

--- a/app/templates/page.tsx
+++ b/app/templates/page.tsx
@@ -15,6 +15,33 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import Image from "next/image";
+import { TemplateProClickTracker } from "@/components/template-pro-click-tracker";
+
+/**
+ * Build the Pro-site preview URL with UTM + ref attribution so we can
+ * measure every template-card click in PostHog/GA4. Free templates keep
+ * their external vercel/github URLs unchanged.
+ */
+function buildPreviewHref(template: Template): string {
+  if (template.price === "free") return template.previewUrl;
+  try {
+    const url = new URL(template.previewUrl);
+    url.searchParams.set("ref", "oss_templates");
+    url.searchParams.set("utm_source", "ruixen");
+    url.searchParams.set("utm_medium", "template_card");
+    url.searchParams.set("utm_campaign", "bridge");
+    url.searchParams.set("slug", template.id);
+    return url.toString();
+  } catch {
+    return template.previewUrl;
+  }
+}
+
+function buildGetProHref(slug: string): string {
+  return `https://pro.ruixen.com/pricing?ref=oss_templates_get_pro&slug=${encodeURIComponent(
+    slug,
+  )}`;
+}
 
 export const metadata: Metadata = {
   title: "Templates",
@@ -35,9 +62,13 @@ interface Template {
   features: string[];
   author: string;
   publishedAt: string;
+  category?: string;
 }
 
 const templates: Template[] = [
+  // ============================================
+  // FREE TEMPLATES
+  // ============================================
   {
     id: "portfolio",
     title: "Creative Portfolio Template",
@@ -69,6 +100,901 @@ const templates: Template[] = [
     ],
     author: "srinathg",
     publishedAt: "2024-08-10",
+    category: "Full Templates",
+  },
+
+  // ============================================
+  // PRO HERO SECTIONS
+  // ============================================
+  {
+    id: "hero-bars",
+    title: "Hero Bars",
+    description:
+      "Animated vertical bars with wave effects and centered title overlay. Visually striking hero background with symmetrical scaling.",
+    image: "/showcase/hero-bars-light.mp4",
+    video: "/showcase/hero-bars-dark.mp4",
+    previewUrl: "https://pro.ruixen.com/docs/components/hero-bars",
+    price: "pro",
+    technologies: [
+      "Next.js",
+      "React",
+      "TypeScript",
+      "Tailwind CSS",
+      "Framer Motion",
+    ],
+    features: [
+      "Animated vertical bars with wave motion",
+      "Symmetrical scaling from center",
+      "Customizable gradient colors",
+      "Adjustable wave intensity and timing",
+      "Optional centered title overlay",
+      "Toggle animation on/off",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-01-10",
+    category: "Hero Sections",
+  },
+  {
+    id: "hero-mobile-showcase",
+    title: "Hero Mobile Showcase",
+    description:
+      "A hero section with animated split text and centered mobile phone mockup. Perfect for app landing pages.",
+    image: "/showcase/hero-mobile-showcase-light.mp4",
+    video: "/showcase/hero-mobile-showcase-dark.mp4",
+    previewUrl: "https://pro.ruixen.com/docs/components/hero-mobile-showcase",
+    price: "pro",
+    technologies: [
+      "Next.js",
+      "React",
+      "TypeScript",
+      "Tailwind CSS",
+      "Framer Motion",
+    ],
+    features: [
+      "Animated split text effect",
+      "Centered mobile phone mockup",
+      "Smooth entrance animations",
+      "Responsive design",
+      "Dark mode support",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-01-12",
+    category: "Hero Sections",
+  },
+  {
+    id: "hero-cursor-cards",
+    title: "Hero Cursor Cards",
+    description:
+      "A hero section with floating cursor pointers, following cursor effect, three overlapping cards in diamond layout, and logo cloud.",
+    image: "/showcase/hero-bars-light.mp4",
+    previewUrl: "https://pro.ruixen.com/docs/components/hero-cursor-cards",
+    price: "pro",
+    technologies: [
+      "Next.js",
+      "React",
+      "TypeScript",
+      "Tailwind CSS",
+      "Framer Motion",
+    ],
+    features: [
+      "Floating cursor pointers",
+      "Mouse-following effect",
+      "Overlapping diamond card layout",
+      "Logo cloud integration",
+      "Smooth animations",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-01-14",
+    category: "Hero Sections",
+  },
+  {
+    id: "hero-dot-pattern",
+    title: "Hero Dot Pattern",
+    description:
+      "A hero section with dot pattern background, fixed navbar with scroll-aware styling, logo cloud slider, and themed dashboard preview.",
+    image: "/showcase/hero-bars-light.mp4",
+    previewUrl: "https://pro.ruixen.com/docs/components/hero-dot-pattern",
+    price: "pro",
+    technologies: [
+      "Next.js",
+      "React",
+      "TypeScript",
+      "Tailwind CSS",
+      "Framer Motion",
+      "next-themes",
+    ],
+    features: [
+      "Dot pattern background",
+      "Scroll-aware fixed navbar",
+      "Logo cloud slider",
+      "Dashboard preview mockup",
+      "Theme support",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-01-16",
+    category: "Hero Sections",
+  },
+  {
+    id: "hero-tabs-dashboard",
+    title: "Hero Tabs Dashboard",
+    description:
+      "A hero section with tabbed feature navigation, dashboard sidebar preview, junction dot accents, and crosshatch background pattern.",
+    image: "/showcase/hero-bars-light.mp4",
+    previewUrl: "https://pro.ruixen.com/docs/components/hero-tabs-dashboard",
+    price: "pro",
+    technologies: [
+      "Next.js",
+      "React",
+      "TypeScript",
+      "Tailwind CSS",
+      "Lucide React",
+    ],
+    features: [
+      "Tabbed feature navigation",
+      "Dashboard sidebar preview",
+      "Junction dot accents",
+      "Crosshatch background pattern",
+      "Responsive layout",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-01-18",
+    category: "Hero Sections",
+  },
+
+  // ============================================
+  // PRO TESTIMONIALS
+  // ============================================
+  {
+    id: "testimonials-split-tabs",
+    title: "Testimonials Split Tabs",
+    description:
+      "An elegant split-view testimonial component with animated image tabs that expand on hover. Perfect for showcasing client feedback.",
+    image: "/showcase/testimonials-split-tabs-light.mp4",
+    video: "/showcase/testimonials-split-tabs-dark.mp4",
+    previewUrl:
+      "https://pro.ruixen.com/docs/components/testimonials-split-tabs",
+    price: "pro",
+    technologies: [
+      "Next.js",
+      "React",
+      "TypeScript",
+      "Tailwind CSS",
+      "Framer Motion",
+    ],
+    features: [
+      "Smooth hover-to-activate animations",
+      "Split-view layout with image and quote",
+      "Keyboard navigation support",
+      "Responsive mobile/desktop design",
+      "Customizable height and flex ratios",
+      "Accessible ARIA attributes",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-01-15",
+    category: "Testimonials",
+  },
+  {
+    id: "testimonials-map",
+    title: "Testimonials World Map",
+    description:
+      "A stunning world map visualization that displays testimonials distributed by country. Features 3D globe effect on mobile.",
+    image: "/showcase/map-location-picker-light.mp4",
+    video: "/showcase/map-location-picker-dark.mp4",
+    previewUrl: "https://pro.ruixen.com/docs/components/testimonials-map",
+    price: "pro",
+    technologies: [
+      "Next.js",
+      "React",
+      "TypeScript",
+      "Tailwind CSS",
+      "Framer Motion",
+    ],
+    features: [
+      "Interactive world map visualization",
+      "Country-based testimonial placement",
+      "3D globe curve effect on mobile",
+      "Hover tooltips with details",
+      "Responsive scaling",
+      "100+ country support",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-01-20",
+    category: "Testimonials",
+  },
+
+  // ============================================
+  // PRO ANIMATIONS & EFFECTS
+  // ============================================
+  {
+    id: "scroll-fx",
+    title: "Scroll FX Gallery",
+    description:
+      "A Three.js-powered cinematic scroll-driven media gallery with focus detection and dynamic text. Infinite scroll with images and videos.",
+    image: "/showcase/scroll-fx-light.mp4",
+    video: "/showcase/scroll-fx-dark.mp4",
+    previewUrl: "https://pro.ruixen.com/docs/components/scroll-fx",
+    price: "pro",
+    technologies: [
+      "Next.js",
+      "React",
+      "Three.js",
+      "@react-three/fiber",
+      "@react-three/drei",
+    ],
+    features: [
+      "Mixed images and videos (MP4, WebM)",
+      "Infinite scrolling",
+      "Automatic focus detection",
+      "Dynamic text labels",
+      "Smooth wheel + drag interaction",
+      "Sharp WebGL rendering",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-01-22",
+    category: "Animations",
+  },
+  {
+    id: "scroll-fx-timeline",
+    title: "Scroll FX Timeline",
+    description:
+      "A scroll-driven timeline component with visual effects and animated progress indicators.",
+    image: "/showcase/scroll-fx-timeline-light.mp4",
+    video: "/showcase/scroll-fx-timeline-dark.mp4",
+    previewUrl: "https://pro.ruixen.com/docs/components/scroll-fx-timeline",
+    price: "pro",
+    technologies: [
+      "Next.js",
+      "React",
+      "TypeScript",
+      "Tailwind CSS",
+      "Framer Motion",
+    ],
+    features: [
+      "Scroll-driven animations",
+      "Timeline progress indicator",
+      "Visual effects on scroll",
+      "Responsive design",
+      "Dark mode support",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-01-24",
+    category: "Animations",
+  },
+  {
+    id: "scroll-split-video-gallery",
+    title: "Scroll Split Video Gallery",
+    description:
+      "A split-screen video gallery with scroll interaction and responsive design. Perfect for showcasing video content.",
+    image: "/showcase/scroll-split-video-gallery-light.mp4",
+    video: "/showcase/scroll-split-video-gallery-dark.mp4",
+    previewUrl:
+      "https://pro.ruixen.com/docs/components/scroll-split-video-gallery",
+    price: "pro",
+    technologies: ["Next.js", "React", "TypeScript", "Tailwind CSS"],
+    features: [
+      "Split-screen layout",
+      "Scroll-driven video playback",
+      "Responsive design",
+      "Smooth transitions",
+      "Video autoplay on focus",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-01-26",
+    category: "Animations",
+  },
+  {
+    id: "bloom-text",
+    title: "Bloom Text",
+    description:
+      "Text with blooming flower animation effect. A beautiful way to highlight important text with organic motion.",
+    image: "/showcase/bloom-text-light.mp4",
+    video: "/showcase/bloom-text-dark.mp4",
+    previewUrl: "https://pro.ruixen.com/docs/components/bloom-text",
+    price: "pro",
+    technologies: ["Next.js", "React", "TypeScript", "Tailwind CSS"],
+    features: [
+      "Blooming flower animation",
+      "CSS-only animations",
+      "Dark mode support",
+      "Customizable timing",
+      "Lightweight implementation",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-01-28",
+    category: "Animations",
+  },
+  {
+    id: "cta-meteor",
+    title: "CTA Meteor",
+    description:
+      "A cinematic CTA section with meteor animation that falls and expands. Features gradient effects and particle animations.",
+    image: "/showcase/cta-meteor-light.mp4",
+    video: "/showcase/cta-meteor-dark.mp4",
+    previewUrl: "https://pro.ruixen.com/docs/components/cta-meteor",
+    price: "pro",
+    technologies: [
+      "Next.js",
+      "React",
+      "TypeScript",
+      "Tailwind CSS",
+      "Framer Motion",
+      "Lucide React",
+    ],
+    features: [
+      "Cinematic meteor falling animation",
+      "Width expansion effect after impact",
+      "Floating particle system",
+      "Large gradient background text",
+      "Primary and secondary CTA buttons",
+      "Viewport-triggered animation",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-02-01",
+    category: "CTA Sections",
+  },
+  {
+    id: "project-title-morph",
+    title: "Project Title Morph",
+    description:
+      "A morphing project title animation component with button interaction. Text transforms smoothly between states.",
+    image: "/showcase/project-title-morph-light.mp4",
+    video: "/showcase/project-title-morph-dark.mp4",
+    previewUrl: "https://pro.ruixen.com/docs/components/project-title-morph",
+    price: "pro",
+    technologies: [
+      "Next.js",
+      "React",
+      "TypeScript",
+      "Tailwind CSS",
+      "Framer Motion",
+      "Lucide React",
+    ],
+    features: [
+      "Text morphing animation",
+      "Button interaction trigger",
+      "Smooth state transitions",
+      "Customizable text content",
+      "Dark mode support",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-02-03",
+    category: "Animations",
+  },
+
+  // ============================================
+  // PRO NAVIGATION
+  // ============================================
+  {
+    id: "apple-mega-nav",
+    title: "Apple Mega Nav",
+    description:
+      "Apple-style mega navigation menu with accordion and sheet support. Clean, minimal design with smooth animations.",
+    image: "/showcase/apple-mega-nav-light.mp4",
+    video: "/showcase/apple-mega-nav-dark.mp4",
+    previewUrl: "https://pro.ruixen.com/docs/components/apple-mega-nav",
+    price: "pro",
+    technologies: [
+      "Next.js",
+      "React",
+      "TypeScript",
+      "Tailwind CSS",
+      "@radix-ui/react-navigation-menu",
+      "Lucide React",
+    ],
+    features: [
+      "Apple-style mega menu",
+      "Accordion support",
+      "Mobile sheet navigation",
+      "Smooth animations",
+      "Accessible keyboard navigation",
+      "Dark mode support",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-02-05",
+    category: "Navigation",
+  },
+
+  // ============================================
+  // PRO INTERACTIVE COMPONENTS
+  // ============================================
+  {
+    id: "instagram-stories",
+    title: "Instagram Stories",
+    description:
+      "A fully-featured Instagram Stories component with progress bars, video support, swipe navigation, and like/reply actions.",
+    image: "/showcase/instagram-stories-light.mp4",
+    video: "/showcase/instagram-stories-dark.mp4",
+    previewUrl: "https://pro.ruixen.com/docs/components/instagram-stories",
+    price: "pro",
+    technologies: [
+      "Next.js",
+      "React",
+      "TypeScript",
+      "Tailwind CSS",
+      "Framer Motion",
+      "Lucide React",
+    ],
+    features: [
+      "Animated avatar trigger with gradient ring",
+      "Progress bars for each story",
+      "Support for images and videos",
+      "Swipe/tap navigation",
+      "Hold to pause functionality",
+      "Keyboard navigation",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-02-07",
+    category: "Interactive",
+  },
+  {
+    id: "map-location-picker",
+    title: "Map Location Picker",
+    description:
+      "An interactive map component with location cards, pagination, and real-time selection using Leaflet.",
+    image: "/showcase/map-location-picker-light.mp4",
+    video: "/showcase/map-location-picker-dark.mp4",
+    previewUrl: "https://pro.ruixen.com/docs/components/map-location-picker",
+    price: "pro",
+    technologies: [
+      "Next.js",
+      "React",
+      "TypeScript",
+      "Tailwind CSS",
+      "Framer Motion",
+      "react-leaflet",
+      "Leaflet",
+    ],
+    features: [
+      "Interactive map with markers",
+      "Location cards with details",
+      "Pagination support",
+      "Real-time selection",
+      "Customizable markers",
+      "Responsive design",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-02-09",
+    category: "Interactive",
+  },
+  {
+    id: "models-carousel",
+    title: "Models Carousel",
+    description:
+      "A carousel component for displaying models like AI models or product variants with smooth transitions.",
+    image: "/showcase/models-carousel-light.mp4",
+    video: "/showcase/models-carousel-dark.mp4",
+    previewUrl: "https://pro.ruixen.com/docs/components/models-carousel",
+    price: "pro",
+    technologies: ["Next.js", "React", "TypeScript", "Tailwind CSS"],
+    features: [
+      "Smooth carousel transitions",
+      "Model/variant display",
+      "Navigation controls",
+      "Responsive design",
+      "Dark mode support",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-02-11",
+    category: "Interactive",
+  },
+  {
+    id: "accordion-with-image-tooltip",
+    title: "Accordion with Image Tooltip",
+    description:
+      "An accordion component with image tooltips on hover. Combines information hierarchy with visual previews.",
+    image: "/showcase/accordion-with-image-tooltip-light.mp4",
+    video: "/showcase/accordion-with-image-tooltip-dark.mp4",
+    previewUrl:
+      "https://pro.ruixen.com/docs/components/accordion-with-image-tooltip",
+    price: "pro",
+    technologies: [
+      "Next.js",
+      "React",
+      "TypeScript",
+      "Tailwind CSS",
+      "Framer Motion",
+      "Lucide React",
+    ],
+    features: [
+      "Accordion with tooltips",
+      "Image preview on hover",
+      "Smooth expand/collapse",
+      "Accessible keyboard support",
+      "Dark mode support",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-02-13",
+    category: "Interactive",
+  },
+
+  // ============================================
+  // PRO FOOTER SECTIONS
+  // ============================================
+  {
+    id: "flicker-footer",
+    title: "Flicker Footer",
+    description:
+      "A sticky reveal footer with tube light flicker animation effect on headline text. Eye-catching and memorable.",
+    image: "/showcase/flicker-footer-light.mp4",
+    video: "/showcase/flicker-footer-dark.mp4",
+    previewUrl: "https://pro.ruixen.com/docs/components/flicker-footer",
+    price: "pro",
+    technologies: [
+      "Next.js",
+      "React",
+      "TypeScript",
+      "Tailwind CSS",
+      "Framer Motion",
+    ],
+    features: [
+      "Sticky reveal on scroll",
+      "Tube light flicker animation",
+      "Headline text effect",
+      "Navigation links",
+      "Dark mode support",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-02-15",
+    category: "Footers",
+  },
+  {
+    id: "footer-reveal",
+    title: "Footer Reveal",
+    description:
+      "A sticky reveal footer with navigation, hero typography, and optional images that reveals on scroll.",
+    image: "/showcase/flicker-footer-light.mp4",
+    previewUrl: "https://pro.ruixen.com/docs/components/footer-reveal",
+    price: "pro",
+    technologies: [
+      "Next.js",
+      "React",
+      "TypeScript",
+      "Tailwind CSS",
+      "Framer Motion",
+      "Lucide React",
+    ],
+    features: [
+      "Sticky reveal animation",
+      "Hero typography",
+      "Optional background images",
+      "Navigation links",
+      "Social media icons",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-02-17",
+    category: "Footers",
+  },
+
+  // ============================================
+  // PRO BENTO GRIDS & SERVICES
+  // ============================================
+  {
+    id: "feature-bento-grid",
+    title: "Feature Bento Grid",
+    description:
+      "A beautiful bento grid layout for showcasing features with corner accents, dot patterns, and various card styles.",
+    image: "/showcase/hero-bars-light.mp4",
+    previewUrl: "https://pro.ruixen.com/docs/components/feature-bento-grid",
+    price: "pro",
+    technologies: [
+      "Next.js",
+      "React",
+      "TypeScript",
+      "Tailwind CSS",
+      "Framer Motion",
+    ],
+    features: [
+      "Bento grid layout",
+      "Corner plus accents",
+      "Dot pattern backgrounds",
+      "Multiple card types",
+      "Dark mode support",
+      "Responsive design",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-02-19",
+    category: "Bento Grids",
+  },
+  {
+    id: "services-bento-grid",
+    title: "Services Bento Grid",
+    description:
+      "A bento grid layout for services with dashboard preview, stats, testimonial, kanban board, and resource usage cards.",
+    image: "/showcase/hero-bars-light.mp4",
+    previewUrl: "https://pro.ruixen.com/docs/components/services-bento-grid",
+    price: "pro",
+    technologies: [
+      "Next.js",
+      "React",
+      "TypeScript",
+      "Tailwind CSS",
+      "Lucide React",
+    ],
+    features: [
+      "Dashboard preview card",
+      "Stats display",
+      "Testimonial integration",
+      "Kanban board card",
+      "Resource usage display",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-02-21",
+    category: "Bento Grids",
+  },
+  {
+    id: "workflow-bento-grid",
+    title: "Workflow Bento Grid",
+    description:
+      "A bento grid layout showcasing workflow automation features with connected cards, status indicators, and dot patterns.",
+    image: "/showcase/hero-bars-light.mp4",
+    previewUrl: "https://pro.ruixen.com/docs/components/workflow-bento-grid",
+    price: "pro",
+    technologies: [
+      "Next.js",
+      "React",
+      "TypeScript",
+      "Tailwind CSS",
+      "Framer Motion",
+    ],
+    features: [
+      "Connected workflow cards",
+      "Visual connection lines",
+      "Status indicators with AI badges",
+      "Multiple card types",
+      "Responsive design",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-02-23",
+    category: "Bento Grids",
+  },
+  {
+    id: "services-interactive-cards",
+    title: "Services Interactive Cards",
+    description:
+      "A services section with three interactive cards showcasing AI task breakdown, team workflow diagram, and automated engagement.",
+    image: "/showcase/hero-bars-light.mp4",
+    previewUrl:
+      "https://pro.ruixen.com/docs/components/services-interactive-cards",
+    price: "pro",
+    technologies: [
+      "Next.js",
+      "React",
+      "TypeScript",
+      "Tailwind CSS",
+      "Framer Motion",
+    ],
+    features: [
+      "SignalCard with AI task breakdown",
+      "SequenceCard with workflow diagram",
+      "AutomateCard with carousel",
+      "Smooth motion animations",
+      "Responsive grid layout",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-02-25",
+    category: "Services",
+  },
+  {
+    id: "services-scroll",
+    title: "Services Scroll",
+    description:
+      "A scroll-driven services section with animated cards that stack and transform as you scroll.",
+    image: "/showcase/hero-bars-light.mp4",
+    previewUrl: "https://pro.ruixen.com/docs/components/services-scroll",
+    price: "pro",
+    technologies: [
+      "Next.js",
+      "React",
+      "TypeScript",
+      "Tailwind CSS",
+      "Framer Motion",
+    ],
+    features: [
+      "Scroll-driven animations",
+      "Stacking card effect",
+      "Transform on scroll",
+      "Responsive design",
+      "Dark mode support",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-02-27",
+    category: "Services",
+  },
+
+  // ============================================
+  // PRO STATS & COUNTERS
+  // ============================================
+  {
+    id: "stats-counter",
+    title: "Stats Counter",
+    description:
+      "An animated stats section with scroll-triggered number counters, customizable values, and responsive grid layout.",
+    image: "/showcase/hero-bars-light.mp4",
+    previewUrl: "https://pro.ruixen.com/docs/components/stats-counter",
+    price: "pro",
+    technologies: [
+      "Next.js",
+      "React",
+      "TypeScript",
+      "Tailwind CSS",
+      "Framer Motion",
+      "@number-flow/react",
+    ],
+    features: [
+      "Scroll-triggered animation",
+      "Smooth number counter animation",
+      "Customizable stats with suffixes",
+      "Configurable animation delays",
+      "Responsive grid layout",
+      "Gradient border separators",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-03-01",
+    category: "Stats",
+  },
+  {
+    id: "stats-row",
+    title: "Stats Row",
+    description:
+      "A horizontal stats section with staggered animations, vertical dividers, and descriptions for each metric.",
+    image: "/showcase/hero-bars-light.mp4",
+    previewUrl: "https://pro.ruixen.com/docs/components/stats-row",
+    price: "pro",
+    technologies: [
+      "Next.js",
+      "React",
+      "TypeScript",
+      "Tailwind CSS",
+      "Framer Motion",
+      "@number-flow/react",
+    ],
+    features: [
+      "Horizontal layout",
+      "Staggered animations",
+      "Vertical dividers",
+      "Metric descriptions",
+      "Dark mode support",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-03-03",
+    category: "Stats",
+  },
+
+  // ============================================
+  // PRO MISCELLANEOUS
+  // ============================================
+  {
+    id: "logo-cloud-animated",
+    title: "Logo Cloud Animated",
+    description:
+      "An animated logo cloud with cycling logos, grid layout, and corner plus icons. Perfect for showcasing partners.",
+    image: "/showcase/hero-bars-light.mp4",
+    previewUrl: "https://pro.ruixen.com/docs/components/logo-cloud-animated",
+    price: "pro",
+    technologies: [
+      "Next.js",
+      "React",
+      "TypeScript",
+      "Tailwind CSS",
+      "Framer Motion",
+      "Lucide React",
+    ],
+    features: [
+      "Cycling logo animation",
+      "Grid layout",
+      "Corner plus icons",
+      "Customizable timing",
+      "Dark mode support",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-03-05",
+    category: "Logo Clouds",
+  },
+  {
+    id: "integrations-grid",
+    title: "Integrations Grid",
+    description:
+      "A responsive grid layout showcasing integration cards with brand logos, titles, and descriptions.",
+    image: "/showcase/hero-bars-light.mp4",
+    previewUrl: "https://pro.ruixen.com/docs/components/integrations-grid",
+    price: "pro",
+    technologies: [
+      "Next.js",
+      "React",
+      "TypeScript",
+      "Tailwind CSS",
+      "Framer Motion",
+    ],
+    features: [
+      "Integration cards",
+      "Brand logos support",
+      "Responsive grid",
+      "Hover animations",
+      "Dark mode support",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-03-07",
+    category: "Grids",
+  },
+  {
+    id: "masonry-grid",
+    title: "Masonry Grid",
+    description:
+      "A responsive masonry grid layout with scroll-driven animations and hover effects using GSAP.",
+    image: "/showcase/hero-bars-light.mp4",
+    previewUrl: "https://pro.ruixen.com/docs/components/masonry-grid",
+    price: "pro",
+    technologies: [
+      "Next.js",
+      "React",
+      "TypeScript",
+      "Tailwind CSS",
+      "GSAP",
+      "imagesloaded",
+    ],
+    features: [
+      "Masonry layout",
+      "Scroll-driven animations",
+      "Hover effects",
+      "GSAP powered",
+      "Responsive design",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-03-09",
+    category: "Grids",
+  },
+  {
+    id: "changelog",
+    title: "Changelog Section",
+    description:
+      "A changelog section component with version badges, dates, and entry cards. Track your product updates beautifully.",
+    image: "/showcase/hero-bars-light.mp4",
+    previewUrl: "https://pro.ruixen.com/docs/components/changelog",
+    price: "pro",
+    technologies: [
+      "Next.js",
+      "React",
+      "TypeScript",
+      "Tailwind CSS",
+      "Lucide React",
+    ],
+    features: [
+      "Version badges",
+      "Date display",
+      "Entry cards",
+      "Categorized updates",
+      "Dark mode support",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-03-11",
+    category: "Sections",
+  },
+  {
+    id: "faq-section",
+    title: "FAQ Section",
+    description:
+      "A customizable FAQ accordion section with multiple variants, icons, and smooth animations.",
+    image: "/showcase/hero-bars-light.mp4",
+    previewUrl: "https://pro.ruixen.com/docs/components/faq-section",
+    price: "pro",
+    technologies: [
+      "Next.js",
+      "React",
+      "TypeScript",
+      "Tailwind CSS",
+      "@radix-ui/react-accordion",
+      "Lucide React",
+    ],
+    features: [
+      "Multiple variants",
+      "Icon support",
+      "Smooth animations",
+      "Accessible",
+      "Dark mode support",
+    ],
+    author: "ruixen",
+    publishedAt: "2025-03-13",
+    category: "Sections",
   },
 ];
 
@@ -80,7 +1006,14 @@ function TemplateCard({ template }: { template: Template }) {
         <div className="p-6 space-y-4">
           <CardHeader className="p-0">
             <div className="space-y-1">
-              <CardTitle className="text-2xl">{template.title}</CardTitle>
+              <div className="flex items-center gap-2">
+                <CardTitle className="text-2xl">{template.title}</CardTitle>
+                {template.category && (
+                  <Badge variant="outline" className="text-[10px] font-normal">
+                    {template.category}
+                  </Badge>
+                )}
+              </div>
               <CardDescription>{template.description}</CardDescription>
             </div>
           </CardHeader>
@@ -117,7 +1050,13 @@ function TemplateCard({ template }: { template: Template }) {
 
           <div className="flex gap-2">
             <Button asChild size="lg" variant="outline" className="gap-2">
-              <Link href={template.previewUrl} target="_blank">
+              <Link
+                href={buildPreviewHref(template)}
+                target="_blank"
+                data-pro-template-preview={
+                  template.price === "pro" ? template.id : undefined
+                }
+              >
                 Live Preview
                 <ExternalLinkIcon className="size-4" />
               </Link>
@@ -132,7 +1071,11 @@ function TemplateCard({ template }: { template: Template }) {
               </Button>
             ) : (
               <Button asChild size="lg" variant="default" className="gap-2">
-                <Link href="https://pro.ruixen.com" target="_blank">
+                <Link
+                  href={buildGetProHref(template.id)}
+                  target="_blank"
+                  data-pro-template-get-pro={template.id}
+                >
                   Get Pro
                   <ArrowRightIcon className="size-4" />
                 </Link>
@@ -180,8 +1123,12 @@ function TemplateCard({ template }: { template: Template }) {
 }
 
 export default function TemplatesPage() {
+  const freeTemplates = templates.filter((t) => t.price === "free");
+  const proTemplates = templates.filter((t) => t.price === "pro");
+
   return (
     <div className="container py-8 md:py-12 lg:py-16">
+      <TemplateProClickTracker />
       <div className="mx-auto max-w-6xl">
         {/* Header */}
         <div className="text-center space-y-4 mb-12">
@@ -207,7 +1154,7 @@ export default function TemplatesPage() {
           </div>
           <div className="text-center space-y-2">
             <div className="text-2xl font-bold text-primary">
-              {templates.filter((t) => t.price === "free").length}
+              {freeTemplates.length}
             </div>
             <div className="text-sm text-muted-foreground">Free Templates</div>
           </div>
@@ -219,12 +1166,29 @@ export default function TemplatesPage() {
           </div>
         </div>
 
-        {/* Templates Grid */}
-        <div className="space-y-8 mb-12">
-          {templates.map((template) => (
-            <TemplateCard key={template.id} template={template} />
-          ))}
-        </div>
+        {/* Free Templates */}
+        {freeTemplates.length > 0 && (
+          <div className="mb-16">
+            <h2 className="text-2xl font-bold mb-6">Free Templates</h2>
+            <div className="space-y-8">
+              {freeTemplates.map((template) => (
+                <TemplateCard key={template.id} template={template} />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Pro Templates */}
+        {proTemplates.length > 0 && (
+          <div className="mb-12">
+            <h2 className="text-2xl font-bold mb-6">Pro Templates</h2>
+            <div className="space-y-8">
+              {proTemplates.map((template) => (
+                <TemplateCard key={template.id} template={template} />
+              ))}
+            </div>
+          </div>
+        )}
 
         {/* Pro Templates CTA */}
         <div className="relative py-16 md:py-24">
@@ -243,8 +1207,8 @@ export default function TemplatesPage() {
             </h2>
 
             <p className="mt-4 text-[0.95rem] leading-relaxed text-muted-foreground/70 max-w-sm mx-auto">
-              50+ production-ready components, templates, and blocks. Lifetime
-              updates included.
+              {proTemplates.length}+ production-ready components, templates, and
+              blocks. Lifetime updates included.
             </p>
 
             {/* Price */}
@@ -258,8 +1222,9 @@ export default function TemplatesPage() {
             {/* CTA Buttons */}
             <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-3">
               <Link
-                href="https://pro.ruixen.com"
+                href="https://pro.ruixen.com/pricing?ref=oss_templates_footer"
                 target="_blank"
+                data-pro-template-get-pro="__footer__"
                 className="group inline-flex h-10 items-center gap-2 rounded-full bg-foreground px-6 text-[13px] font-medium text-background transition-all duration-200 hover:opacity-85"
               >
                 Get Pro Access

--- a/components/analytics.tsx
+++ b/components/analytics.tsx
@@ -16,7 +16,8 @@ export function Analytics() {
           "description": "170+ free, open-source React components built with Tailwind CSS, TypeScript & Framer Motion.",
           "sameAs": [
             "https://twitter.com/ruixen_ui",
-            "https://github.com/ruixenui/ruixen.com"
+            "https://github.com/ruixenui/ruixen.com",
+            "https://pro.ruixen.com"
           ]
         }
       `}</Script>

--- a/components/main-nav.tsx
+++ b/components/main-nav.tsx
@@ -9,11 +9,29 @@ import {
 } from "@/components/ui/context-menu";
 import { docsConfig } from "@/config/docs";
 import { siteConfig } from "@/config/site";
+import { trackEvent, type Event } from "@/lib/events";
 import { cn } from "@/lib/utils";
 import { ExternalLinkIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import Image from "next/image";
+
+// Whitelist of nav items that may carry a trackable event. Keeps the cast
+// narrow — every nav-configured event name must exist in the global event
+// enum in lib/events.ts.
+const NAV_EVENTS: readonly Event["name"][] = [
+  "pro_nav_clicked",
+  "header_cta_clicked",
+  "navigation",
+  "view_docs",
+];
+
+function fireNavEvent(eventName: string | undefined) {
+  if (!eventName) return;
+  if ((NAV_EVENTS as readonly string[]).includes(eventName)) {
+    trackEvent({ name: eventName as Event["name"] });
+  }
+}
 
 function copyLogoAsSVG(path: string) {
   fetch(path)
@@ -148,9 +166,16 @@ export function MainNav() {
             return (
               <Link
                 key={item.href}
-                href={item.href!}
+                href="https://pro.ruixen.com/pricing?ref=oss_nav"
                 aria-label={item.title}
                 target="_blank"
+                onClick={() => {
+                  fireNavEvent(item.event);
+                  trackEvent({
+                    name: "oss_pro_cta_clicked",
+                    properties: { surface: "nav" },
+                  });
+                }}
                 className="flex items-center justify-center font-semibold"
               >
                 <span
@@ -174,6 +199,7 @@ export function MainNav() {
               href={item.href!}
               aria-label={item.title}
               target={item.external ? "_blank" : undefined}
+              onClick={() => fireNavEvent(item.event)}
               className={cn(
                 "flex items-center justify-center transition-colors hover:text-foreground/80",
                 isActive ? "text-foreground" : "text-foreground/60",

--- a/components/mdx-components.tsx
+++ b/components/mdx-components.tsx
@@ -17,6 +17,7 @@ import Link from "next/link";
 import { ComponentPreview } from "@/components/component-preview";
 import { ComponentSource } from "@/components/component-source";
 import { CopyButton } from "@/components/copy-button";
+import { ProInlineCallout } from "@/components/pro-inline-callout";
 import { TemplateOpen } from "@/components/template-open";
 import { SimpleComponentsShowcase } from "@/components/simple-components-showcase";
 import {
@@ -101,7 +102,13 @@ const components = {
   TemplatePreview,
   Image,
   ComponentPreview,
-  ComponentSource: (props: any) => <ComponentSource {...props} />,
+  ComponentSource: (props: any) => (
+    <>
+      <ComponentSource {...props} />
+      {/* Auto-injected Pro upsell — see components/pro-inline-callout.tsx */}
+      <ProInlineCallout slug={props?.name} />
+    </>
+  ),
   SimpleComponentsShowcase,
   AllComponentsShowcase,
   CategoryShowcase,

--- a/components/posthog-provider.tsx
+++ b/components/posthog-provider.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { Suspense, useEffect } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import posthog from "posthog-js";
+import { PostHogProvider } from "posthog-js/react";
+
+// Gate initialization on production + API key so local dev never fires
+// events into the production PostHog project. Mirrors the pro.ruixen.com
+// pattern at components/posthog-provider.tsx.
+const isProduction = process.env.NODE_ENV === "production";
+const hasApiKey = Boolean(process.env.NEXT_PUBLIC_POSTHOG_API_KEY);
+
+// `cross_subdomain_cookie: true` with `localStorage+cookie` persistence
+// writes the anonymous distinct_id into a `.ruixen.com` domain cookie so
+// a visitor who clicks from ruixen.com/docs/components → pro.ruixen.com
+// keeps the same identity. Without this, the OSS → Pro funnel is
+// invisible in PostHog. Both sites must use the SAME project API key.
+if (typeof window !== "undefined" && isProduction && hasApiKey) {
+  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_API_KEY!, {
+    api_host:
+      process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://us.i.posthog.com",
+    capture_pageview: false, // We capture manually below
+    persistence: "localStorage+cookie",
+    cross_subdomain_cookie: true,
+    disable_session_recording: true,
+    advanced_disable_decide: true,
+  });
+}
+
+function PostHogPageviewInner(): React.ReactNode {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (pathname && isProduction && hasApiKey) {
+      let url = window.origin + pathname;
+      if (searchParams && searchParams.toString()) {
+        url = url + `?${searchParams.toString()}`;
+      }
+      posthog.capture("$pageview", {
+        $current_url: url,
+      });
+    }
+  }, [pathname, searchParams]);
+
+  return null;
+}
+
+/**
+ * Pageview tracker. Wrapped in `<Suspense>` so `useSearchParams()` does
+ * not force a CSR bailout during static prerender in Next 15.
+ */
+export function PostHogPageview(): React.ReactNode {
+  return (
+    <Suspense fallback={null}>
+      <PostHogPageviewInner />
+    </Suspense>
+  );
+}
+
+export function PHProvider({ children }: { children: React.ReactNode }) {
+  // In dev or without an API key we pass through — `trackEvent` gates
+  // the same way in lib/events.ts so nothing fires.
+  if (!isProduction || !hasApiKey) {
+    return <>{children}</>;
+  }
+
+  return (
+    <PostHogProvider client={posthog}>
+      <PostHogPageview />
+      {children}
+    </PostHogProvider>
+  );
+}

--- a/components/pro-announcement-toast.tsx
+++ b/components/pro-announcement-toast.tsx
@@ -3,29 +3,55 @@
 import { useEffect } from "react";
 import { toast } from "sonner";
 import { Sparkles } from "lucide-react";
+import { trackEvent } from "@/lib/events";
 
+/**
+ * Announcement toast. Shown once per session, gated to unauthenticated-feel
+ * users who have scrolled past the hero. Auto-dismissing popups without
+ * behavioral intent are an anti-pattern — we defer until scroll ≥ 40% of
+ * viewport height so we only hit users who engaged with the page.
+ */
 export function ProAnnouncementToast() {
   useEffect(() => {
     const hasSeenToast = sessionStorage.getItem("ruixen-pro-toast-seen");
+    if (hasSeenToast) return;
 
-    if (!hasSeenToast) {
-      const timer = setTimeout(() => {
-        toast("Ruixen Pro is now live!", {
-          description:
-            "50+ premium components, templates & blocks. Get lifetime access.",
-          duration: 6000,
-          icon: <Sparkles className="h-5 w-5 text-blue-500" />,
-          position: "top-right",
-          action: {
-            label: "Explore Pro",
-            onClick: () => window.open("https://pro.ruixen.com", "_blank"),
+    let fired = false;
+    const fire = () => {
+      if (fired) return;
+      fired = true;
+      toast("Ruixen Pro is now live!", {
+        description:
+          "50+ premium components, templates & blocks. Get lifetime access.",
+        duration: 6000,
+        icon: <Sparkles className="h-5 w-5 text-blue-500" />,
+        position: "top-right",
+        action: {
+          label: "Explore Pro",
+          onClick: () => {
+            trackEvent({
+              name: "oss_pro_cta_clicked",
+              properties: { surface: "toast" },
+            });
+            window.open(
+              "https://pro.ruixen.com/pricing?ref=oss_toast",
+              "_blank",
+            );
           },
-        });
-        sessionStorage.setItem("ruixen-pro-toast-seen", "true");
-      }, 2000);
+        },
+      });
+      sessionStorage.setItem("ruixen-pro-toast-seen", "true");
+      window.removeEventListener("scroll", handleScroll);
+    };
 
-      return () => clearTimeout(timer);
-    }
+    const handleScroll = () => {
+      const scrolled = window.scrollY;
+      const vh = window.innerHeight;
+      if (scrolled > vh * 0.4) fire();
+    };
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
   return null;

--- a/components/pro-inline-callout.tsx
+++ b/components/pro-inline-callout.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import Link from "next/link";
+import { ChevronRight, Sparkles } from "lucide-react";
+
+import { trackEvent } from "@/lib/events";
+import { PRO_COMPONENT_MAP } from "@/data/pro-component-map";
+
+interface ProInlineCalloutProps {
+  /**
+   * The free component slug. If a Pro counterpart exists in
+   * `PRO_COMPONENT_MAP`, the callout deep-links there; otherwise it falls
+   * through to /pricing.
+   */
+  slug?: string;
+}
+
+/**
+ * Inline Pro upsell rendered under every `<ComponentSource>` on the OSS
+ * docs site. Injected via a single wrap in `components/mdx-components.tsx`
+ * so no individual MDX file needs to change.
+ */
+export function ProInlineCallout({ slug }: ProInlineCalloutProps) {
+  const proSlug = slug ? PRO_COMPONENT_MAP[slug] : undefined;
+  const href = proSlug
+    ? `https://pro.ruixen.com/docs/components/${proSlug}?ref=oss_docs_inline`
+    : `https://pro.ruixen.com/pricing?ref=oss_docs_inline`;
+
+  return (
+    <div className="my-6 rounded-xl border border-blue-300/60 bg-blue-50/40 dark:border-blue-500/30 dark:bg-blue-950/20 p-4">
+      <div className="flex items-start gap-3">
+        <Sparkles className="mt-0.5 size-4 shrink-0 text-blue-600 dark:text-blue-400" />
+        <div className="flex-1">
+          <p className="text-sm font-medium text-foreground">
+            {proSlug
+              ? "Want the Pro version of this component?"
+              : "Need more than this?"}
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Ruixen Pro adds 50+ components with advanced motion and theming,
+            plus full page templates. One payment, lifetime updates.
+          </p>
+        </div>
+        <Link
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() =>
+            trackEvent({
+              name: "oss_pro_cta_clicked",
+              properties: {
+                surface: "inline_docs_upsell",
+                slug: slug ?? null,
+              },
+            })
+          }
+          className="shrink-0 inline-flex items-center gap-1 rounded-md bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-blue-700"
+        >
+          {proSlug ? "See Pro" : "Get Pro"}
+          <ChevronRight className="size-3" />
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/components/sections/hero.tsx
+++ b/components/sections/hero.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import React, { useState, useEffect, useCallback } from "react";
 import { Copy, Check } from "lucide-react";
 import { trackCTAClick } from "@/lib/ga-events";
+import { trackEvent } from "@/lib/events";
 import { HeroTitleAnimation } from "@/registry/ruixenui/hero-title-animation";
 
 const CLI_COMMAND = 'npx shadcn@latest add "https://ruixen.com/r/[component]"';
@@ -37,8 +38,14 @@ function Home() {
             }}
           >
             <Link
-              href="https://pro.ruixen.com"
+              href="https://pro.ruixen.com/pricing?ref=oss_hero"
               target="_blank"
+              onClick={() =>
+                trackEvent({
+                  name: "oss_pro_cta_clicked",
+                  properties: { surface: "hero" },
+                })
+              }
               className="relative inline-block text-[11px] font-medium uppercase tracking-[0.15em] text-transparent bg-clip-text transition-opacity duration-150 hover:opacity-80"
               style={{
                 backgroundImage:

--- a/components/sections/pricing-landing.tsx
+++ b/components/sections/pricing-landing.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Check, ChevronRight, Sparkles } from "lucide-react";
+
+import { trackEvent } from "@/lib/events";
+
+interface PricingSnapshot {
+  amountCents: number;
+  display: string;
+  currency: string;
+}
+
+const FALLBACK: PricingSnapshot = {
+  amountCents: 5900,
+  display: "$59",
+  currency: "USD",
+};
+
+const FEATURES = [
+  "All 50+ premium components",
+  "Production templates (Intellune, Nguyen)",
+  "Lifetime updates — no subscription",
+  "Commercial license included",
+  "Source code via shadcn CLI",
+  "Priority support on Discord",
+  "Early access to new releases",
+  "Unlimited projects",
+];
+
+const FREE_VS_PRO = [
+  {
+    label: "Components",
+    free: "170+ open-source",
+    pro: "170+ free + 50+ premium",
+  },
+  { label: "Templates", free: "1 portfolio", pro: "2 production templates" },
+  { label: "Motion & theming", free: "Basic", pro: "Advanced presets" },
+  { label: "Updates", free: "Community", pro: "Lifetime, priority" },
+  { label: "Commercial license", free: "MIT", pro: "Included" },
+  { label: "Support", free: "GitHub", pro: "Discord priority" },
+];
+
+export function PricingLanding() {
+  const [price, setPrice] = useState<PricingSnapshot>(FALLBACK);
+
+  useEffect(() => {
+    trackEvent({ name: "oss_pricing_page_viewed" });
+    let cancelled = false;
+    fetch("/api/pricing")
+      .then((r) => r.json())
+      .then((data: PricingSnapshot) => {
+        if (!cancelled && data?.display) setPrice(data);
+      })
+      .catch(() => {
+        // Keep the fallback
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleCtaClick = (surface: string) =>
+    trackEvent({
+      name: "oss_pro_cta_clicked",
+      properties: { surface },
+    });
+
+  const checkoutHref = `https://pro.ruixen.com/pricing?ref=oss_pricing_page`;
+
+  return (
+    <main className="relative">
+      {/* Hero */}
+      <section className="container mx-auto max-w-3xl px-4 pt-16 text-center md:pt-24">
+        <div className="inline-flex items-center gap-2 rounded-full border border-blue-300/60 bg-blue-50/40 dark:bg-blue-950/20 px-3 py-1 text-xs font-medium text-blue-600 dark:text-blue-400">
+          <Sparkles className="size-3" />
+          <span>Lifetime access, one payment</span>
+        </div>
+        <h1 className="mt-6 text-4xl font-semibold tracking-tight md:text-5xl lg:text-6xl">
+          Ruixen Pro — one payment, lifetime access
+        </h1>
+        <p className="mt-4 text-balance text-lg text-muted-foreground">
+          50+ premium React components, 2 production templates, unlimited
+          updates. Pay once, ship forever.
+        </p>
+      </section>
+
+      {/* Price card */}
+      <section className="container mx-auto max-w-md px-4 py-12 md:py-16">
+        <div className="rounded-2xl border bg-card p-6 shadow-sm">
+          <div className="flex items-baseline gap-2">
+            <span className="text-5xl font-semibold tracking-tight">
+              {price.display}
+            </span>
+            <span className="text-muted-foreground">{price.currency}</span>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            One-time payment, lifetime access
+          </p>
+
+          <ul className="mt-6 space-y-3">
+            {FEATURES.map((feature) => (
+              <li key={feature} className="flex items-start gap-2 text-sm">
+                <div className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-emerald-500/20">
+                  <Check className="h-2.5 w-2.5 text-emerald-500" />
+                </div>
+                <span>{feature}</span>
+              </li>
+            ))}
+          </ul>
+
+          <Link
+            href={checkoutHref}
+            target="_blank"
+            onClick={() => handleCtaClick("pricing_page")}
+            className="mt-6 inline-flex w-full items-center justify-center gap-2 rounded-lg bg-foreground px-4 py-2.5 text-sm font-semibold text-background hover:opacity-90"
+          >
+            Get Lifetime — {price.display}
+            <ChevronRight className="size-4" />
+          </Link>
+          <p className="mt-3 text-center text-xs text-muted-foreground">
+            14-day money-back guarantee
+          </p>
+        </div>
+      </section>
+
+      {/* Free vs Pro */}
+      <section className="container mx-auto max-w-4xl px-4 py-12 md:py-16">
+        <h2 className="text-center text-2xl font-semibold md:text-3xl">
+          Free vs Pro
+        </h2>
+        <p className="mt-2 text-center text-sm text-muted-foreground">
+          The 170+ free components stay free forever. Pro adds the premium tier
+          on top.
+        </p>
+        <div className="mt-10 overflow-hidden rounded-xl border">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/50">
+              <tr className="text-left">
+                <th className="p-4 font-medium">&nbsp;</th>
+                <th className="p-4 font-medium">Free (OSS)</th>
+                <th className="p-4 font-medium">Pro</th>
+              </tr>
+            </thead>
+            <tbody>
+              {FREE_VS_PRO.map((row) => (
+                <tr key={row.label} className="border-t">
+                  <td className="p-4 font-medium">{row.label}</td>
+                  <td className="p-4 text-muted-foreground">{row.free}</td>
+                  <td className="p-4">{row.pro}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* Bottom CTA */}
+      <section className="container mx-auto max-w-2xl px-4 pb-24 text-center">
+        <Link
+          href={checkoutHref}
+          target="_blank"
+          onClick={() => handleCtaClick("pricing_page_bottom")}
+          className="inline-flex items-center gap-2 rounded-full bg-foreground px-6 py-3 text-sm font-semibold text-background hover:opacity-90"
+        >
+          Get Lifetime — {price.display}
+          <ChevronRight className="size-4" />
+        </Link>
+        <p className="mt-4 text-xs text-muted-foreground">
+          Questions? Email{" "}
+          <a className="underline" href="mailto:support@ruixen.com">
+            support@ruixen.com
+          </a>
+          .
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/components/sections/pro-section.tsx
+++ b/components/sections/pro-section.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import Link from "next/link";
+import { Sparkles, ChevronRight, Check } from "lucide-react";
+
+import { trackEvent } from "@/lib/events";
+
+const FEATURES = [
+  "50+ premium components with motion and theming",
+  "2 production-ready templates (Intellune, Nguyen)",
+  "Lifetime updates — no subscription",
+  "Commercial license included",
+  "Shadcn-compatible CLI install",
+  "Priority support on Discord",
+];
+
+/**
+ * Homepage Pro section. Introduced as part of the OSS → Pro bridge so
+ * ruixen.com visitors encounter a dedicated upgrade surface inline (not
+ * buried in nav, footer, or FAQ). Links to the new /pricing mirror and
+ * also to pro.ruixen.com directly.
+ */
+export function ProSection() {
+  const handleCta = (surface: string) =>
+    trackEvent({
+      name: "oss_pro_cta_clicked",
+      properties: { surface },
+    });
+
+  return (
+    <section className="py-16 md:py-24">
+      <div className="container mx-auto max-w-5xl px-4">
+        <div className="mx-auto max-w-2xl text-center">
+          <div className="inline-flex items-center gap-2 rounded-full border border-blue-300/60 bg-blue-50/40 dark:bg-blue-950/20 px-3 py-1 text-xs font-medium text-blue-600 dark:text-blue-400">
+            <Sparkles className="size-3" />
+            <span>Ruixen Pro</span>
+          </div>
+          <h2 className="mt-4 text-3xl md:text-4xl font-semibold tracking-tight">
+            When the free library isn&apos;t enough
+          </h2>
+          <p className="mt-4 text-muted-foreground">
+            Pro adds 50+ premium components, full page templates, and lifetime
+            updates. One payment. No subscription. Everything you ship looks
+            like it was made by a team.
+          </p>
+        </div>
+
+        <div className="mt-10 grid gap-3 md:grid-cols-2">
+          {FEATURES.map((feature) => (
+            <div
+              key={feature}
+              className="flex items-start gap-2 rounded-lg border border-border/60 bg-card p-3"
+            >
+              <Check className="mt-0.5 size-4 shrink-0 text-blue-600 dark:text-blue-400" />
+              <span className="text-sm">{feature}</span>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-10 flex flex-col items-center gap-3">
+          <Link
+            href="https://pro.ruixen.com/pricing?ref=oss_homepage_section"
+            target="_blank"
+            onClick={() => handleCta("homepage_section")}
+            className="inline-flex items-center gap-2 rounded-xl bg-foreground px-5 py-2.5 text-sm font-semibold text-background hover:opacity-90"
+          >
+            Get Lifetime — $59
+            <ChevronRight className="size-4" />
+          </Link>
+          <Link
+            href="/pricing"
+            onClick={() => handleCta("homepage_section_compare")}
+            className="text-xs text-muted-foreground hover:text-foreground underline"
+          >
+            Compare Free vs Pro →
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/sidebar-cta.tsx
+++ b/components/sidebar-cta.tsx
@@ -4,6 +4,7 @@ import { ChevronRight, Check } from "lucide-react";
 import Link from "next/link";
 import { useTheme } from "next-themes";
 import { useState, useEffect, useRef } from "react";
+import { trackEvent } from "@/lib/events";
 
 // Showcase videos - each has light/dark variants
 const SHOWCASE_VIDEOS = [
@@ -86,8 +87,14 @@ function VideoSlideshow() {
 export function ProCTA() {
   return (
     <Link
-      href="https://pro.ruixen.com"
+      href="https://pro.ruixen.com/pricing?ref=oss_sidebar"
       target="_blank"
+      onClick={() =>
+        trackEvent({
+          name: "oss_pro_cta_clicked",
+          properties: { surface: "sidebar" },
+        })
+      }
       className="group my-6 flex w-full flex-col overflow-hidden rounded-xl bg-card border border-blue-300 dark:border-blue-600/50 cursor-pointer transition-all hover:border-blue-400 dark:hover:border-blue-500 hover:shadow-md"
     >
       {/* Video Slideshow */}

--- a/components/site-banner.tsx
+++ b/components/site-banner.tsx
@@ -3,14 +3,21 @@
 import { ChevronRight } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { trackEvent } from "@/lib/events";
 
 export function ProBanner() {
   return (
     <div className="group relative top-0 bg-blue-600 py-3 text-white transition-all duration-300 md:py-0">
       <div className="container flex flex-col items-center justify-center gap-4 md:h-12 md:flex-row">
         <Link
-          href="https://pro.ruixen.com"
+          href="https://pro.ruixen.com/pricing?ref=oss_banner"
           target="_blank"
+          onClick={() =>
+            trackEvent({
+              name: "oss_pro_cta_clicked",
+              properties: { surface: "banner" },
+            })
+          }
           className="relative inline-flex text-sm leading-normal md:text-md"
         >
           <span className="text-[1rem] font-semibold">
@@ -51,7 +58,14 @@ export function ProductHuntBanner() {
 export function SiteBanner() {
   const pathname = usePathname();
 
-  if (pathname === "/showcase" || pathname.startsWith("/blog")) {
+  // Banner runs on the homepage + marketing surfaces only. On docs/components
+  // (the 993-user catalog) the sidebar CTA carries the upsell load, so the
+  // banner would compete for attention and dilute both.
+  if (
+    pathname === "/showcase" ||
+    pathname.startsWith("/blog") ||
+    pathname.startsWith("/docs")
+  ) {
     return null;
   }
 

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import Image from "next/image";
+import { trackEvent } from "@/lib/events";
 
 const footerSections = [
   {
@@ -65,7 +68,10 @@ const footerSections = [
   {
     heading: "Community & Support",
     links: [
-      { label: "Ruixen Pro", href: "https://pro.ruixen.com" },
+      {
+        label: "Ruixen Pro",
+        href: "https://pro.ruixen.com/pricing?ref=oss_footer",
+      },
       { label: "Documentation", href: "/docs" },
       { label: "Blog", href: "/blog" },
       // { label: "Discord Server", href: "https://discord.gg/bYexWzUa6G" },
@@ -118,6 +124,14 @@ export default function SiteFooter() {
                   <li key={j}>
                     <a
                       href={link.href}
+                      onClick={() => {
+                        if (link.label === "Ruixen Pro") {
+                          trackEvent({
+                            name: "oss_pro_cta_clicked",
+                            properties: { surface: "footer" },
+                          });
+                        }
+                      }}
                       className="flex items-center text-muted-foreground hover:text-foreground transition"
                     >
                       {link.label}

--- a/components/template-pro-click-tracker.tsx
+++ b/components/template-pro-click-tracker.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { trackEvent } from "@/lib/events";
+
+/**
+ * Delegated click tracker for the /templates page. Hoisted into its own
+ * client component so app/templates/page.tsx can stay a server component.
+ *
+ * Fires:
+ *  - `oss_template_preview_clicked` on any `[data-pro-template-preview]` click
+ *  - `oss_pro_cta_clicked` with `surface: template_preview` on the same click
+ *  - `oss_pro_cta_clicked` with `surface: template_get_pro` on "Get Pro" clicks
+ */
+export function TemplateProClickTracker() {
+  useEffect(() => {
+    const handler = (event: MouseEvent) => {
+      const target = event.target as HTMLElement | null;
+
+      const previewLink = target?.closest<HTMLElement>(
+        "[data-pro-template-preview]",
+      );
+      if (previewLink) {
+        const slug = previewLink.dataset.proTemplatePreview ?? null;
+        trackEvent({
+          name: "oss_template_preview_clicked",
+          properties: { slug },
+        });
+        trackEvent({
+          name: "oss_pro_cta_clicked",
+          properties: { surface: "template_preview", slug },
+        });
+        return;
+      }
+
+      const getProLink = target?.closest<HTMLElement>(
+        "[data-pro-template-get-pro]",
+      );
+      if (getProLink) {
+        const slug = getProLink.dataset.proTemplateGetPro ?? null;
+        trackEvent({
+          name: "oss_pro_cta_clicked",
+          properties: {
+            surface:
+              slug === "__footer__" ? "template_footer" : "template_get_pro",
+            slug: slug === "__footer__" ? null : slug,
+          },
+        });
+      }
+    };
+    document.addEventListener("click", handler);
+    return () => document.removeEventListener("click", handler);
+  }, []);
+  return null;
+}

--- a/data/pro-component-map.ts
+++ b/data/pro-component-map.ts
@@ -1,0 +1,25 @@
+/**
+ * Free OSS component slug → Pro counterpart slug.
+ *
+ * Keyed on the `<ComponentSource name="...">` value on the free site.
+ * When a mapping exists, the inline docs callout deep-links to the Pro
+ * equivalent. Unknown slugs fall through to /pricing.
+ *
+ * Keep this list small and curated — every entry ships traffic to pro.ruixen
+ * and the destination must exist there. Add a row only after confirming the
+ * Pro component is live.
+ */
+export const PRO_COMPONENT_MAP: Record<string, string> = {
+  "accordion-editorial": "accordion-with-image-tooltip",
+  "hero-sections": "hero-bars",
+  "split-hero-section": "hero-mobile-showcase",
+  "card-carousel-hero": "hero-cursor-cards",
+  "gradient-hero-showcase": "hero-dot-pattern",
+  "video-hero-showcase": "hero-tabs-dashboard",
+  "footer-section": "flicker-footer",
+  "footer-pro": "footer-reveal",
+  testimonials: "testimonials-map",
+  "stats-counter": "star-counter-wheel",
+  "services-bento-grid": "services-bento-grid",
+  "feature-bento-grid": "feature-bento-grid",
+};

--- a/deploy.sh
+++ b/deploy.sh
@@ -16,6 +16,43 @@ exec > >(tee -a "$LOG_FILE") 2>&1
 
 echo "=== Deployment started at $(date) ==="
 
+# ============================================================================
+# ENVIRONMENT VALIDATION — fail fast before spending 2 minutes on a build
+# that is going to ship a broken bundle. All NEXT_PUBLIC_* vars must be in
+# .env BEFORE `pnpm build` runs; they are inlined into the client bundle at
+# build time and cannot be fixed by restarting PM2 afterward.
+# ============================================================================
+
+if [ ! -f .env ]; then
+  echo "ERROR: .env not found at repo root. Create it with the required"
+  echo "       NEXT_PUBLIC_* vars before deploying."
+  exit 1
+fi
+
+REQUIRED_VARS=(
+  NEXT_PUBLIC_POSTHOG_API_KEY
+  NEXT_PUBLIC_POSTHOG_HOST
+)
+
+for var in "${REQUIRED_VARS[@]}"; do
+  value=$(grep -E "^${var}=" .env | cut -d= -f2- | sed 's/^"//;s/"$//' || true)
+  if [ -z "$value" ]; then
+    echo "ERROR: ${var} is missing or empty in .env."
+    echo "       The PostHog client will be disabled in production and the"
+    echo "       funnel-correction dashboards will receive zero events."
+    echo "       Add ${var}=... to .env and rerun ./deploy.sh"
+    exit 1
+  fi
+  # Log a fingerprint (first 12 chars) so the human can eyeball the value
+  # without leaking it into deploy logs.
+  echo "✓ ${var} present (${value:0:12}...)"
+done
+
+POSTHOG_KEY_FINGERPRINT=$(grep -E '^NEXT_PUBLIC_POSTHOG_API_KEY=' .env \
+  | cut -d= -f2- \
+  | sed 's/^"//;s/"$//' \
+  | head -c 12)
+
 # Clean lockfile if corrupted
 if ! pnpm install --lockfile-only 2>&1 | grep -q "broken lockfile"; then
   echo "Lockfile OK"
@@ -28,9 +65,33 @@ fi
 echo "Installing dependencies..."
 pnpm install --no-frozen-lockfile
 
+# Clean Next cache so new client imports (e.g. posthog-provider) are picked
+# up — the project CLAUDE.md calls this out explicitly: only clean .next,
+# never .content-collections.
+echo "Cleaning .next cache..."
+rm -rf .next
+
 # Build the application
 echo "Building application..."
 pnpm build
+
+# ============================================================================
+# POST-BUILD VERIFICATION — confirm the PostHog key actually got baked into
+# the client bundle. If the user accidentally edits env.mjs or changes the
+# provider path, this grep fails fast BEFORE PM2 serves the broken build.
+# ============================================================================
+echo "Verifying PostHog key was inlined into the client bundle..."
+if grep -rq --include='*.js' "${POSTHOG_KEY_FINGERPRINT}" .next/static 2>/dev/null; then
+  echo "✓ PostHog key found in client bundle — tracking will be live after PM2 restart"
+else
+  echo "ERROR: PostHog key fingerprint ${POSTHOG_KEY_FINGERPRINT}... was"
+  echo "       not found in any .next/static/**/*.js file."
+  echo "       The build completed but PostHog init will be dead code in"
+  echo "       production. Likely cause: posthog-provider.tsx was not"
+  echo "       imported from app/layout.tsx, or lib/events.ts stopped"
+  echo "       calling posthog.capture(), or the Zod enum rejected an event."
+  exit 1
+fi
 
 # Copy static assets for standalone build
 echo "Copying static assets..."
@@ -46,3 +107,9 @@ cd ../..
 
 echo "=== Deployment completed at $(date) ==="
 echo "Log file: $LOG_FILE"
+echo ""
+echo "Verify in the browser:"
+echo "  1. Open https://ruixen.com in incognito"
+echo "  2. DevTools Console: window.posthog?.config?.token"
+echo "  3. Should print the key, not undefined"
+echo "  4. Then open PostHog Live Events and click any Pro CTA"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,10 +22,19 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        # NEXT_PUBLIC_* vars are baked into the client bundle at build
+        # time. Provide via shell env or a top-level .env file next to
+        # this docker-compose.yml. Use the SAME PostHog project key as
+        # pro.ruixen.com so cross-subdomain identity stitching works.
+        - NEXT_PUBLIC_POSTHOG_API_KEY=${NEXT_PUBLIC_POSTHOG_API_KEY:-}
+        - NEXT_PUBLIC_POSTHOG_HOST=${NEXT_PUBLIC_POSTHOG_HOST:-https://us.i.posthog.com}
     ports:
       - "3000:3000"
     environment:
       - NODE_ENV=production
+      - NEXT_PUBLIC_POSTHOG_API_KEY=${NEXT_PUBLIC_POSTHOG_API_KEY:-}
+      - NEXT_PUBLIC_POSTHOG_HOST=${NEXT_PUBLIC_POSTHOG_HOST:-https://us.i.posthog.com}
     profiles:
       - prod
     restart: unless-stopped

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -1,5 +1,13 @@
 import { z } from "zod";
+import posthog from "posthog-js";
 import { sendGAEvent } from "./ga-events";
+
+// Gate PostHog capture on the same conditions as the provider so local
+// dev never pollutes the production project and `trackEvent` stays a
+// no-op when the key isn't set.
+const POSTHOG_ENABLED =
+  process.env.NODE_ENV === "production" &&
+  Boolean(process.env.NEXT_PUBLIC_POSTHOG_API_KEY);
 
 const eventSchema = z.object({
   name: z.enum([
@@ -36,6 +44,16 @@ const eventSchema = z.object({
 
     // Settings
     "theme_change",
+
+    // OSS → Pro funnel (added by funnel-correction plan)
+    "oss_pro_cta_clicked",
+    "oss_pricing_page_viewed",
+    "oss_template_preview_clicked",
+    "pro_nav_clicked",
+
+    // Header/nav CTA events referenced in config/docs.ts
+    "header_cta_clicked",
+    "gradients_clicked",
   ]),
   // declare type AllowedPropertyValues = string | number | boolean | null
   properties: z
@@ -46,12 +64,27 @@ const eventSchema = z.object({
 export type Event = z.infer<typeof eventSchema>;
 
 /**
- * Track an event to Google Analytics 4
+ * Track an event to both Google Analytics 4 and PostHog.
+ *
+ * GA4 stays wired for historical continuity; PostHog is the
+ * product-analytics source of truth for the funnel-correction plan
+ * (OSS → Pro bridge, price consistency audit, etc.). Using the same
+ * project key as pro.ruixen.com plus cross-subdomain cookies means a
+ * visitor who crosses domains is a single PostHog identity.
  */
 export function trackEvent(input: Event): void {
   const event = eventSchema.parse(input);
-  if (event) {
-    // Send to GA4
-    sendGAEvent(event.name, event.properties || {});
+  if (!event) return;
+
+  // GA4 (legacy)
+  sendGAEvent(event.name, event.properties || {});
+
+  // PostHog (funnel source of truth)
+  if (POSTHOG_ENABLED) {
+    try {
+      posthog.capture(event.name, event.properties);
+    } catch {
+      // Never let an analytics failure break a user interaction
+    }
   }
 }

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -106,6 +106,33 @@ Every component is published in 4 variants:
 - **Pro Version:** https://pro.ruixen.com
 
 ================================================================================
+## RUIXEN PRO (Commercial Tier)
+================================================================================
+
+Ruixen Pro is a one-time paid upgrade that sits alongside the free library.
+Everything in the free 170+ component library stays free forever; Pro adds
+a premium tier on top.
+
+### Pricing
+- **$59 USD lifetime** — one payment, no subscription, no renewals
+- 14-day money-back guarantee
+- Commercial license included
+- Unlimited personal and commercial projects
+
+### What's Included
+- 50+ premium components with advanced motion and theming
+- 2 production-ready templates (Intellune AI workspace, Nguyen SaaS)
+- Lifetime updates — every new Pro component included
+- Priority support via Discord
+- Shadcn CLI integration: `npx shadcn@latest add https://pro.ruixen.com/r/[component]`
+- Early access to new releases
+
+### URLs
+- **Pricing:** https://ruixen.com/pricing and https://pro.ruixen.com/pricing
+- **Pro catalog:** https://pro.ruixen.com/docs/components
+- **Pro templates:** https://pro.ruixen.com/templates
+
+================================================================================
 ## COMPONENT CATALOG (170+ Components)
 ================================================================================
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -9,6 +9,7 @@ Ruixen UI provides professionally-crafted React components that behave like phys
 - Website: https://ruixen.com
 - GitHub: https://github.com/ruixenui/ruixen.com
 - License: MIT
+- Ruixen Pro: https://pro.ruixen.com — 50+ premium components + production templates, $59 lifetime, one payment, no subscription. See https://ruixen.com/pricing or https://pro.ruixen.com/pricing for details.
 
 ## Key Features
 


### PR DESCRIPTION
## Summary

Phase 2 of the funnel correction plan plus Step 2 PostHog wiring for the OSS site. Six thematic commits on top of origin/main.

- **PostHog cross-subdomain stitching** + event catalog extension so OSS → Pro visitors stitch into one identity
- **Pro CTA instrumentation** across sidebar, banner, nav, footer, hero, toast (the sidebar CTA was untracked — no clicks had ever been captured)
- **Dedicated `/pricing` mirror page** + `/api/pricing` ISR proxy with fallback — fixes the "2 users on /pricing" finding from the Feb–Mar audit
- **Inline Pro callout on every `/docs/components/*` page** via one wrap in `mdx-components.tsx` — closes the biggest leak (993 warm users with zero in-content upsell)
- **Homepage ProSection** between WallOfLove and FAQSection, plus FAQ copy mentioning `$59 lifetime`
- **Template card UTMs + delegated click tracker** so all preview clicks carry attribution
- **SEO updates**: sitemap (/pricing + /templates), Organization schema `sameAs: pro.ruixen.com`, llms.txt with a full Ruixen Pro section
- **Dockerfile + docker-compose + deploy.sh hardening**: build args for PostHog, env validation, post-build bundle grep that fails fast if the key didn't get inlined

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm build` — passes (`/pricing` = 4.71 kB, `/api/pricing` present in manifest, PostHog key verified inlined in `.next/static/**`)
- [ ] Deploy to prod, add `NEXT_PUBLIC_POSTHOG_API_KEY` + `NEXT_PUBLIC_POSTHOG_HOST` to the prod `.env`, run `./deploy.sh`
- [ ] Open `https://ruixen.com` incognito → `window.posthog?.config?.token` prints the key (not `undefined`)
- [ ] Click any Pro CTA → PostHog Live Events shows `oss_pro_cta_clicked { surface: ... }`
- [ ] Verify cross-subdomain stitching: click from ruixen.com sidebar → pro.ruixen.com/pricing → same `distinct_id` in both events