### PR TITLE
fix(landing): close hero-to-components gap

### DIFF
--- a/components/sections/component-categories.tsx
+++ b/components/sections/component-categories.tsx
@@ -232,7 +232,7 @@ export function ComponentCategories() {
   const theme = mounted ? (resolvedTheme ?? "light") : "light";
 
   return (
-    <section className="relative z-10 w-full px-4 sm:px-6 md:px-10 lg:px-16 pt-16 md:pt-24 pb-16 md:pb-24">
+    <section className="relative z-10 w-full px-4 sm:px-6 md:px-10 lg:px-16 pt-0 pb-16 md:pb-24">
       <div className="mx-auto max-w-[1400px]">
         <div className="flex justify-center mb-6 md:mb-10">
           <span className="text-[11px] font-medium uppercase tracking-[0.15em] text-foreground/35">

--- a/components/sections/component-categories.tsx
+++ b/components/sections/component-categories.tsx
@@ -232,7 +232,7 @@ export function ComponentCategories() {
   const theme = mounted ? (resolvedTheme ?? "light") : "light";
 
   return (
-    <section className="relative z-10 w-full px-4 sm:px-6 md:px-10 lg:px-16 pt-0 pb-16 md:pb-24">
+    <section className="relative z-10 w-full px-4 sm:px-6 md:px-10 lg:px-16 -mt-20 md:-mt-28 pt-0 pb-16 md:pb-24">
       <div className="mx-auto max-w-[1400px]">
         <div className="flex justify-center mb-6 md:mb-10">
           <span className="text-[11px] font-medium uppercase tracking-[0.15em] text-foreground/35">

--- a/content/docs/mcp.mdx
+++ b/content/docs/mcp.mdx
@@ -37,15 +37,15 @@ Restart your editor after saving. Three Ruixen tools will appear in your assista
 
 ### Where each editor stores its config
 
-| Editor          | Where to put the config |
-|-----------------|--------------------------|
-| **Cursor**      | Settings → Features → Model Context Protocol → **Add new MCP server**, or edit `~/.cursor/mcp.json` directly |
+| Editor             | Where to put the config                                                                                                             |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| **Cursor**         | Settings → Features → Model Context Protocol → **Add new MCP server**, or edit `~/.cursor/mcp.json` directly                        |
 | **Claude Desktop** | `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) · `%APPDATA%\Claude\claude_desktop_config.json` (Windows) |
-| **Claude Code** | Run `claude mcp add ruixen-mcp -- npx -y @ruixen/mcp@latest` |
-| **Windsurf**    | Cascade panel → MCP servers → **Add server** |
-| **Cline**       | MCP Servers tab in the Cline extension panel → **Configure MCP Servers** |
-| **Roo Code**    | MCP Servers tab in the Roo Code extension panel |
-| **VS Code**     | Depends on the MCP extension you use — consult its docs |
+| **Claude Code**    | Run `claude mcp add ruixen-mcp -- npx -y @ruixen/mcp@latest`                                                                        |
+| **Windsurf**       | Cascade panel → MCP servers → **Add server**                                                                                        |
+| **Cline**          | MCP Servers tab in the Cline extension panel → **Configure MCP Servers**                                                            |
+| **Roo Code**       | MCP Servers tab in the Roo Code extension panel                                                                                     |
+| **VS Code**        | Depends on the MCP extension you use — consult its docs                                                                             |
 
 If your editor prefers a one-line command, point it at `npx -y @ruixen/mcp@latest`. That's the entire server — no separate install step, no global package.
 
@@ -75,11 +75,11 @@ Your assistant calls the MCP tools behind the scenes, finds matching components,
 
 Three tools, intentionally small. Most MCP-aware editors cap how many tools a single server can register; this keeps Ruixen well under every cap.
 
-| Tool                   | What it does |
-|------------------------|--------------|
-| `listRegistryItems`    | Browse the full registry with optional filters for `kind`, `query`, and pagination. |
-| `searchRegistryItems`  | Ranked keyword search across names, titles, descriptions, and registry types. |
-| `getRegistryItem`      | Full detail for a single component — install command, source code, related examples, and dependencies. |
+| Tool                  | What it does                                                                                           |
+| --------------------- | ------------------------------------------------------------------------------------------------------ |
+| `listRegistryItems`   | Browse the full registry with optional filters for `kind`, `query`, and pagination.                    |
+| `searchRegistryItems` | Ranked keyword search across names, titles, descriptions, and registry types.                          |
+| `getRegistryItem`     | Full detail for a single component — install command, source code, related examples, and dependencies. |
 
 ## How it works
 


### PR DESCRIPTION
## Summary
- Closes the visible empty band between the hero and the components showcase on the landing page.
- **Root cause:** the hero uses `min-h-[calc(100vh-4rem)]` + `justify-center`. Content (~500px) is shorter than a full viewport, so centering leaves ~128px of unavoidable dead space below the content — independent of any padding tuning.
- **Fix:** two atomic commits on `components/sections/component-categories.tsx`:
  1. Drop `pt-16 md:pt-24` (removes the stacked top padding).
  2. Apply `-mt-20 md:-mt-28` so the section overlaps into the hero's tail. The section already has `relative z-10`, so it renders cleanly above the hero's scroll indicator.
- Hero is unchanged: title still sits at viewport center on first load.

## Test plan
- [ ] Open `/` on a 1920×1080 viewport — confirm "COMPONENTS" label sits close to the scroll indicator instead of floating 200+px below.
- [ ] Check 1440×900 and mobile widths — ensure no overlap between the hero's scroll indicator and the "COMPONENTS" label.
- [ ] Scroll the page — transition between hero and components grid should feel tight, not cavernous.
- [ ] Verify the components grid renders normally below the label (no visual regression in the grid itself).