### PR TITLE
feat(pro-templates): surface pro.ruixen.com catalog on OSS site

### DIFF
--- a/app/(docs)/docs/layout.tsx
+++ b/app/(docs)/docs/layout.tsx
@@ -1,12 +1,14 @@
 import { DocsSidebarNav } from "@/components/sidebar-nav";
 import { TailwindVersionToggle } from "@/components/tailwind-version-toggle";
-import { docsConfig } from "@/config/docs";
+import { getDocsSidebarNav } from "@/lib/docs-nav";
 
-export default function DocsLayout({
+export default async function DocsLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const sidebarNav = await getDocsSidebarNav();
+
   return (
     <div className="container-wrapper">
       <div className="container flex-1 items-start md:grid md:grid-cols-[200px_minmax(0,1fr)] md:gap-8 lg:grid-cols-[220px_minmax(0,1fr)] lg:gap-14">
@@ -18,7 +20,7 @@ export default function DocsLayout({
             <div className="mb-4">
               <TailwindVersionToggle />
             </div>
-            <DocsSidebarNav items={docsConfig.sidebarNav} />
+            <DocsSidebarNav items={sidebarNav} />
           </div>
         </aside>
         {children}

--- a/app/(docs)/docs/templates/[slug]/page.tsx
+++ b/app/(docs)/docs/templates/[slug]/page.tsx
@@ -1,0 +1,444 @@
+import type { Metadata } from "next";
+import type { Doc } from "content-collections";
+
+import { ChevronRightIcon, ExternalLinkIcon } from "@radix-ui/react-icons";
+import { allDocs } from "content-collections";
+import Image from "next/image";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { Contribute } from "@/components/contribute";
+import { Mdx } from "@/components/mdx-components";
+import { DocPager } from "@/components/pager";
+import { SidebarCTA } from "@/components/sidebar-cta";
+import { TableOfContents } from "@/components/toc";
+import { Badge, badgeVariants } from "@/components/ui/badge";
+import { buttonVariants } from "@/components/ui/button";
+import {
+  buildProTemplateUrl,
+  formatUsdFromCents,
+  proTemplatesApi,
+} from "@/lib/pro-api";
+import { getTableOfContents } from "@/lib/toc";
+import { absoluteUrl, cn } from "@/lib/utils";
+import type { ProTemplate } from "@/types/pro-templates";
+
+export const revalidate = 300;
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+type TemplateResolution =
+  | { kind: "mdx"; doc: Doc }
+  | { kind: "pro"; template: ProTemplate };
+
+async function resolveTemplate(
+  slug: string,
+): Promise<TemplateResolution | null> {
+  // MDX first so hand-authored pages (e.g. /docs/templates/portfolio)
+  // keep their full docs treatment (TOC, pager, contribute).
+  const mdxDoc = allDocs.find(
+    (doc) => doc.slugAsParams === `templates/${slug}` && doc.published,
+  );
+  if (mdxDoc) return { kind: "mdx", doc: mdxDoc };
+
+  try {
+    const template = await proTemplatesApi.getBySlug(slug);
+    if (!template.is_active) return null;
+    return { kind: "pro", template };
+  } catch {
+    return null;
+  }
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const resolved = await resolveTemplate(slug);
+  if (!resolved) return { title: "Template Not Found | Ruixen UI" };
+
+  if (resolved.kind === "mdx") {
+    const { doc } = resolved;
+    return {
+      title: `${doc.title} | Ruixen UI`,
+      description: doc.description,
+      openGraph: {
+        title: doc.title,
+        description: doc.description,
+        type: "article",
+        url: absoluteUrl(doc.slug),
+        images: doc.image ? [{ url: doc.image, width: 1200, height: 630 }] : [],
+      },
+      alternates: { canonical: absoluteUrl(doc.slug) },
+    };
+  }
+
+  const { template } = resolved;
+  const canonical = absoluteUrl(`/docs/templates/${template.slug}`);
+  const thumb =
+    template.images.find((img) => img.is_thumbnail) ?? template.images[0];
+  return {
+    title: `${template.name} | Ruixen UI`,
+    description: template.short_description,
+    openGraph: {
+      title: template.name,
+      description: template.short_description,
+      type: "article",
+      url: canonical,
+      images: thumb ? [{ url: thumb.image_url, width: 1200, height: 630 }] : [],
+    },
+    alternates: { canonical },
+  };
+}
+
+export default async function TemplateDetailPage({ params }: PageProps) {
+  const { slug } = await params;
+  const resolved = await resolveTemplate(slug);
+  if (!resolved) notFound();
+
+  if (resolved.kind === "mdx") {
+    return <MdxDocView doc={resolved.doc} />;
+  }
+
+  return <ProTemplateView template={resolved.template} />;
+}
+
+// ============================================================
+// MDX path — mirrors app/(docs)/docs/[[...slug]]/page.tsx so a
+// manually authored template (like Portfolio) keeps its existing
+// treatment even though this specific route shadows the catch-all.
+// ============================================================
+async function MdxDocView({ doc }: { doc: Doc }) {
+  const toc = await getTableOfContents(doc.body.raw);
+
+  return (
+    <main className="relative xl:grid xl:grid-cols-[minmax(0,1fr)_220px] xl:gap-8">
+      <div className="mx-auto w-full min-w-0 max-w-4xl px-2 py-6 lg:px-6 lg:py-8">
+        <div className="mb-4 flex items-center space-x-1 text-sm text-muted-foreground">
+          <div className="truncate">Docs</div>
+          <ChevronRightIcon className="size-4" />
+          <div className="truncate">Templates</div>
+          <ChevronRightIcon className="size-4" />
+          <div className="font-medium text-foreground">{doc.title}</div>
+        </div>
+        <div className="space-y-2">
+          <h1 className={cn("scroll-m-20 text-4xl font-bold tracking-tight")}>
+            {doc.title}
+          </h1>
+          {doc.description && (
+            <p className="text-balance text-lg text-muted-foreground">
+              {doc.description}
+            </p>
+          )}
+        </div>
+        {doc.links ? (
+          <div className="flex items-center space-x-2 pt-4">
+            {doc.links?.doc && (
+              <Link
+                href={doc.links.doc}
+                target="_blank"
+                rel="noreferrer"
+                className={cn(badgeVariants({ variant: "secondary" }), "gap-1")}
+              >
+                Docs
+                <ExternalLinkIcon className="size-3" />
+              </Link>
+            )}
+            {doc.links?.api && (
+              <Link
+                href={doc.links.api}
+                target="_blank"
+                rel="noreferrer"
+                className={cn(badgeVariants({ variant: "secondary" }), "gap-1")}
+              >
+                API Reference
+                <ExternalLinkIcon className="size-3" />
+              </Link>
+            )}
+          </div>
+        ) : null}
+        <div className="pb-12 pt-8">
+          <Mdx code={doc.body.code} />
+        </div>
+        <DocPager doc={doc} />
+      </div>
+      {doc.toc && (
+        <div className="hidden py-6 pl-6 text-sm xl:block">
+          <div className="sticky top-[90px] h-[calc(100vh-3.5rem)] space-y-4">
+            <TableOfContents toc={toc} />
+            <div id="dynamic-toc" />
+            <Contribute doc={doc} />
+            <SidebarCTA />
+          </div>
+        </div>
+      )}
+    </main>
+  );
+}
+
+// ============================================================
+// Pro API path — renders catalog data inside the same docs shell
+// so Pro templates feel like first-class docs pages. All purchase
+// flows link out to pro.ruixen.com with UTM/ref attribution.
+// ============================================================
+const TECH_STACK_LABELS: Record<string, string> = {
+  react: "React",
+  nextjs: "Next.js",
+  vue: "Vue.js",
+  angular: "Angular",
+  tailwind: "Tailwind CSS",
+  tailwindcss: "Tailwind CSS",
+  typescript: "TypeScript",
+  figma: "Figma",
+  "radix-ui": "Radix UI",
+  "shadcn-ui": "shadcn/ui",
+  "framer-motion": "Framer Motion",
+  "react-hook-form": "React Hook Form",
+  zod: "Zod",
+  html_css: "HTML/CSS",
+  flutter: "Flutter",
+  react_native: "React Native",
+  motion: "Motion",
+};
+
+function ProTemplateView({ template }: { template: ProTemplate }) {
+  const thumb =
+    template.images.find((img) => img.is_thumbnail) ?? template.images[0];
+  const videoUrl = template.video_url_light || template.video_url_dark || null;
+  const priceLabel = template.is_free
+    ? "Free"
+    : formatUsdFromCents(template.price_usd_cents);
+  const proDetailHref = buildProTemplateUrl(template.slug, "oss_docs_sidebar");
+  const getAccessHref = buildProTemplateUrl(
+    template.slug,
+    "oss_templates_get_pro",
+  );
+  const previewHref = template.demo_url
+    ? template.demo_url
+    : buildProTemplateUrl(template.slug, "oss_templates_preview");
+
+  return (
+    <main className="relative">
+      <div className="mx-auto w-full min-w-0 max-w-4xl px-2 py-6 lg:px-6 lg:py-8">
+        <div className="mb-4 flex items-center space-x-1 text-sm text-muted-foreground">
+          <div className="truncate">Docs</div>
+          <ChevronRightIcon className="size-4" />
+          <div className="truncate">Templates</div>
+          <ChevronRightIcon className="size-4" />
+          <div className="font-medium text-foreground">{template.name}</div>
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <h1 className="scroll-m-20 text-4xl font-bold tracking-tight">
+              {template.name}
+            </h1>
+            <Badge variant="default" className="bg-[#bef853] text-black">
+              Pro
+            </Badge>
+            {template.category?.name && (
+              <Badge variant="outline" className="text-xs font-normal">
+                {template.category.name}
+              </Badge>
+            )}
+          </div>
+          <p className="text-balance text-lg text-muted-foreground">
+            {template.short_description}
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3 pt-5">
+          <Link
+            href={getAccessHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            data-pro-template-get-pro={template.slug}
+            className={cn(
+              buttonVariants({ variant: "default", size: "lg" }),
+              "gap-2",
+            )}
+          >
+            {template.is_free ? "Get Template" : `Get Access · ${priceLabel}`}
+          </Link>
+          <Link
+            href={previewHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            data-pro-template-preview={template.slug}
+            className={cn(
+              buttonVariants({ variant: "outline", size: "lg" }),
+              "gap-2",
+            )}
+          >
+            Live Preview
+            <ExternalLinkIcon className="size-3" />
+          </Link>
+          <Link
+            href={proDetailHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={cn(
+              buttonVariants({ variant: "ghost", size: "lg" }),
+              "gap-2",
+            )}
+          >
+            View on Ruixen Pro
+            <ExternalLinkIcon className="size-3" />
+          </Link>
+        </div>
+
+        <div className="pt-8">
+          <div className="relative w-full overflow-hidden rounded-xl border bg-muted">
+            {videoUrl ? (
+              <video
+                autoPlay
+                loop
+                muted
+                playsInline
+                src={videoUrl}
+                poster={thumb?.image_url}
+                className="w-full object-cover"
+              />
+            ) : thumb ? (
+              <Image
+                src={thumb.image_url}
+                alt={thumb.alt_text ?? template.name}
+                width={1600}
+                height={900}
+                className="w-full object-cover"
+                unoptimized
+              />
+            ) : null}
+          </div>
+        </div>
+
+        {template.what_is_this && (
+          <section className="pt-10 space-y-3">
+            <h2 className="scroll-m-20 text-2xl font-semibold tracking-tight">
+              What is this
+            </h2>
+            <p className="leading-7 text-muted-foreground">
+              {template.what_is_this}
+            </p>
+          </section>
+        )}
+
+        {template.who_is_this_for && (
+          <section className="pt-8 space-y-3">
+            <h2 className="scroll-m-20 text-2xl font-semibold tracking-tight">
+              Who is this for
+            </h2>
+            <p className="leading-7 text-muted-foreground">
+              {template.who_is_this_for}
+            </p>
+          </section>
+        )}
+
+        {template.highlights && template.highlights.length > 0 && (
+          <section className="pt-8 space-y-3">
+            <h2 className="scroll-m-20 text-2xl font-semibold tracking-tight">
+              Highlights
+            </h2>
+            <ul className="ml-6 list-disc [&>li]:mt-2 text-muted-foreground">
+              {template.highlights.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {template.features && template.features.length > 0 && (
+          <section className="pt-8 space-y-3">
+            <h2 className="scroll-m-20 text-2xl font-semibold tracking-tight">
+              Features
+            </h2>
+            <ul className="ml-6 list-disc [&>li]:mt-2 text-muted-foreground">
+              {template.features.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {template.sections_included &&
+          template.sections_included.length > 0 && (
+            <section className="pt-8 space-y-3">
+              <h2 className="scroll-m-20 text-2xl font-semibold tracking-tight">
+                Sections included
+              </h2>
+              <div className="flex flex-wrap gap-2">
+                {template.sections_included.map((item) => (
+                  <Badge key={item} variant="outline" className="font-normal">
+                    {item}
+                  </Badge>
+                ))}
+              </div>
+            </section>
+          )}
+
+        {template.tech_stack && template.tech_stack.length > 0 && (
+          <section className="pt-8 space-y-3">
+            <h2 className="scroll-m-20 text-2xl font-semibold tracking-tight">
+              Tech stack
+            </h2>
+            <div className="flex flex-wrap gap-2">
+              {template.tech_stack.map((tech) => (
+                <Badge key={tech} variant="secondary" className="font-normal">
+                  {TECH_STACK_LABELS[tech] ?? tech}
+                </Badge>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {template.dependencies &&
+          Object.keys(template.dependencies).length > 0 && (
+            <section className="pt-8 space-y-3">
+              <h2 className="scroll-m-20 text-2xl font-semibold tracking-tight">
+                Dependencies
+              </h2>
+              <div className="overflow-hidden rounded-lg border">
+                <table className="w-full text-sm">
+                  <tbody>
+                    {Object.entries(template.dependencies).map(([k, v]) => (
+                      <tr
+                        key={k}
+                        className="border-b last:border-b-0 [&>td]:px-4 [&>td]:py-2"
+                      >
+                        <td className="font-mono text-foreground">{k}</td>
+                        <td className="font-mono text-muted-foreground">{v}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          )}
+
+        <div className="mt-12 rounded-xl border bg-muted/30 p-6">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="text-sm text-muted-foreground">Available on</p>
+              <p className="font-semibold">Ruixen Pro</p>
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <span className="text-lg font-semibold">{priceLabel}</span>
+              <Link
+                href={getAccessHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                data-pro-template-get-pro={template.slug}
+                className={cn(buttonVariants({ variant: "default" }), "gap-2")}
+              >
+                {template.is_free ? "Get Template" : "Get Access"}
+                <ExternalLinkIcon className="size-3" />
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/templates/page.tsx
+++ b/app/templates/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+import Image from "next/image";
 import Link from "next/link";
 import {
   ArrowRightIcon,
@@ -6,6 +7,13 @@ import {
   GitHubLogoIcon,
 } from "@radix-ui/react-icons";
 
+import type { ProTemplate } from "@/types/pro-templates";
+import {
+  buildProTemplateUrl,
+  formatUsdFromCents,
+  proTemplatesApi,
+} from "@/lib/pro-api";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -13,35 +21,10 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import Image from "next/image";
 import { TemplateProClickTracker } from "@/components/template-pro-click-tracker";
 
-/**
- * Build the Pro-site preview URL with UTM + ref attribution so we can
- * measure every template-card click in PostHog/GA4. Free templates keep
- * their external vercel/github URLs unchanged.
- */
-function buildPreviewHref(template: Template): string {
-  if (template.price === "free") return template.previewUrl;
-  try {
-    const url = new URL(template.previewUrl);
-    url.searchParams.set("ref", "oss_templates");
-    url.searchParams.set("utm_source", "ruixen");
-    url.searchParams.set("utm_medium", "template_card");
-    url.searchParams.set("utm_campaign", "bridge");
-    url.searchParams.set("slug", template.id);
-    return url.toString();
-  } catch {
-    return template.previewUrl;
-  }
-}
-
-function buildGetProHref(slug: string): string {
-  return `https://pro.ruixen.com/pricing?ref=oss_templates_get_pro&slug=${encodeURIComponent(
-    slug,
-  )}`;
-}
+// Pro catalog lives on pro.ruixen.com and is cached at the edge for 5 minutes.
+export const revalidate = 300;
 
 export const metadata: Metadata = {
   title: "Templates",
@@ -49,7 +32,7 @@ export const metadata: Metadata = {
     "Beautiful, responsive templates built with modern web technologies.",
 };
 
-interface Template {
+interface StaticTemplate {
   id: string;
   title: string;
   description: string;
@@ -57,7 +40,7 @@ interface Template {
   video?: string;
   previewUrl: string;
   githubUrl?: string;
-  price: "free" | "pro";
+  price: "free";
   technologies: string[];
   features: string[];
   author: string;
@@ -65,10 +48,8 @@ interface Template {
   category?: string;
 }
 
-const templates: Template[] = [
-  // ============================================
-  // FREE TEMPLATES
-  // ============================================
+// Free templates that ship from this repo (not in the Pro catalog).
+const staticTemplates: StaticTemplate[] = [
   {
     id: "portfolio",
     title: "Creative Portfolio Template",
@@ -104,11 +85,33 @@ const templates: Template[] = [
   },
 ];
 
-function TemplateCard({ template }: { template: Template }) {
+const TECH_STACK_LABELS: Record<string, string> = {
+  react: "React",
+  nextjs: "Next.js",
+  vue: "Vue.js",
+  angular: "Angular",
+  tailwind: "Tailwind CSS",
+  tailwindcss: "Tailwind CSS",
+  typescript: "TypeScript",
+  figma: "Figma",
+  "radix-ui": "Radix UI",
+  "shadcn-ui": "shadcn/ui",
+  "framer-motion": "Framer Motion",
+  "react-hook-form": "React Hook Form",
+  zod: "Zod",
+  html_css: "HTML/CSS",
+  flutter: "Flutter",
+  react_native: "React Native",
+};
+
+function formatTech(tech: string): string {
+  return TECH_STACK_LABELS[tech] ?? tech;
+}
+
+function StaticTemplateCard({ template }: { template: StaticTemplate }) {
   return (
     <Card className="overflow-hidden transition-all duration-300 shadow-none border-0">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-center">
-        {/* Left Content */}
         <div className="p-6 space-y-4">
           <CardHeader className="p-0">
             <div className="space-y-1">
@@ -156,34 +159,17 @@ function TemplateCard({ template }: { template: Template }) {
 
           <div className="flex gap-2">
             <Button asChild size="lg" variant="outline" className="gap-2">
-              <Link
-                href={buildPreviewHref(template)}
-                target="_blank"
-                data-pro-template-preview={
-                  template.price === "pro" ? template.id : undefined
-                }
-              >
+              <Link href={template.previewUrl} target="_blank">
                 Live Preview
                 <ExternalLinkIcon className="size-4" />
               </Link>
             </Button>
 
-            {template.price === "free" && template.githubUrl ? (
+            {template.githubUrl && (
               <Button asChild size="lg" variant="default" className="gap-2">
                 <Link href={template.githubUrl} target="_blank">
                   Download
                   <GitHubLogoIcon className="size-4" />
-                </Link>
-              </Button>
-            ) : (
-              <Button asChild size="lg" variant="default" className="gap-2">
-                <Link
-                  href={buildGetProHref(template.id)}
-                  target="_blank"
-                  data-pro-template-get-pro={template.id}
-                >
-                  Get Pro
-                  <ArrowRightIcon className="size-4" />
                 </Link>
               </Button>
             )}
@@ -195,7 +181,6 @@ function TemplateCard({ template }: { template: Template }) {
           </div>
         </div>
 
-        {/* Right Video/Image */}
         <div className="relative hover:shadow-[0_8px_32px_rgba(0,0,0,0.1)] hover:backdrop-blur-sm transition-all duration-300 rounded-3xl cursor-pointer">
           {template.video ? (
             <video
@@ -222,11 +207,8 @@ function TemplateCard({ template }: { template: Template }) {
             </div>
           )}
           <div className="absolute top-4 right-4">
-            <Badge
-              variant={template.price === "free" ? "secondary" : "default"}
-              className="bg-[#bef853]"
-            >
-              {template.price === "free" ? "Free" : "Pro"}
+            <Badge variant="secondary" className="bg-[#bef853]">
+              Free
             </Badge>
           </div>
         </div>
@@ -235,8 +217,199 @@ function TemplateCard({ template }: { template: Template }) {
   );
 }
 
-export default function TemplatesPage() {
-  const freeTemplates = templates.filter((t) => t.price === "free");
+function ProTemplateCard({ template }: { template: ProTemplate }) {
+  const thumbnail =
+    template.images.find((img) => img.is_thumbnail) ?? template.images[0];
+  // Videos are rendered on the client; pick the light variant for server-rendered
+  // HTML and let the video element fall back if it's missing.
+  const videoUrl = template.video_url_light || template.video_url_dark || null;
+  const priceLabel = template.is_free
+    ? "Free"
+    : formatUsdFromCents(template.price_usd_cents);
+  const detailHref = buildProTemplateUrl(template.slug, "oss_templates");
+  const getProHref = buildProTemplateUrl(
+    template.slug,
+    "oss_templates_get_pro",
+  );
+  const previewHref = template.demo_url
+    ? template.demo_url
+    : buildProTemplateUrl(template.slug, "oss_templates_preview");
+
+  return (
+    <Card className="overflow-hidden transition-all duration-300 shadow-none border-0">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-center">
+        <div className="p-6 space-y-4">
+          <CardHeader className="p-0">
+            <div className="space-y-1">
+              <div className="flex items-center gap-2">
+                <CardTitle className="text-2xl">
+                  <Link
+                    href={detailHref}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    data-pro-template-preview={template.slug}
+                    className="hover:underline"
+                  >
+                    {template.name}
+                  </Link>
+                </CardTitle>
+                {template.category?.name && (
+                  <Badge variant="outline" className="text-[10px] font-normal">
+                    {template.category.name}
+                  </Badge>
+                )}
+              </div>
+              <CardDescription>{template.short_description}</CardDescription>
+            </div>
+          </CardHeader>
+
+          {template.tech_stack && template.tech_stack.length > 0 && (
+            <div className="flex flex-wrap gap-1">
+              {template.tech_stack.slice(0, 4).map((tech) => (
+                <Badge key={tech} variant="outline" className="text-xs">
+                  {formatTech(tech)}
+                </Badge>
+              ))}
+              {template.tech_stack.length > 4 && (
+                <Badge variant="outline" className="text-xs">
+                  +{template.tech_stack.length - 4} more
+                </Badge>
+              )}
+            </div>
+          )}
+
+          {template.highlights && template.highlights.length > 0 && (
+            <div className="space-y-2">
+              <h4 className="text-sm font-medium">Highlights:</h4>
+              <ul className="text-sm text-muted-foreground space-y-1">
+                {template.highlights.slice(0, 3).map((highlight) => (
+                  <li key={highlight} className="flex items-center gap-2">
+                    <div className="size-1.5 rounded-full bg-primary" />
+                    {highlight}
+                  </li>
+                ))}
+                {template.highlights.length > 3 && (
+                  <li className="text-xs text-muted-foreground/70">
+                    +{template.highlights.length - 3} more
+                  </li>
+                )}
+              </ul>
+            </div>
+          )}
+
+          <div className="flex flex-wrap gap-2">
+            <Button asChild size="lg" variant="outline" className="gap-2">
+              <Link
+                href={previewHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                data-pro-template-preview={template.slug}
+              >
+                Live Preview
+                <ExternalLinkIcon className="size-4" />
+              </Link>
+            </Button>
+
+            <Button asChild size="lg" variant="default" className="gap-2">
+              <Link
+                href={getProHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                data-pro-template-get-pro={template.slug}
+              >
+                {template.is_free
+                  ? "Get Template"
+                  : `Get Access · ${priceLabel}`}
+                <ArrowRightIcon className="size-4" />
+              </Link>
+            </Button>
+          </div>
+
+          <div className="flex items-center justify-between text-xs text-muted-foreground pt-4 border-t">
+            <span>{priceLabel}</span>
+            <span>
+              {template.version ? `v${template.version}` : "Ruixen Pro"}
+            </span>
+          </div>
+        </div>
+
+        <Link
+          href={detailHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          data-pro-template-preview={template.slug}
+          className="relative block hover:shadow-[0_8px_32px_rgba(0,0,0,0.1)] hover:backdrop-blur-sm transition-all duration-300 rounded-3xl cursor-pointer"
+        >
+          {videoUrl ? (
+            <video
+              autoPlay
+              loop
+              muted
+              playsInline
+              className="w-full h-[26rem] rounded-3xl hover:scale-[1.06] transition-all duration-300 object-cover"
+              src={videoUrl}
+              poster={thumbnail?.image_url}
+            />
+          ) : thumbnail ? (
+            <Image
+              src={thumbnail.image_url}
+              alt={thumbnail.alt_text ?? template.name}
+              width={1200}
+              height={800}
+              className="w-full h-[26rem] rounded-3xl object-cover object-top"
+              unoptimized
+            />
+          ) : (
+            <div
+              aria-hidden
+              className="w-full h-[26rem] rounded-3xl bg-gradient-to-br from-muted to-muted/40 flex items-center justify-center text-muted-foreground text-sm"
+            >
+              {template.name}
+            </div>
+          )}
+          <div className="absolute top-4 right-4">
+            <Badge
+              variant={template.is_free ? "secondary" : "default"}
+              className="bg-[#bef853]"
+            >
+              {template.is_free ? "Free" : "Pro"}
+            </Badge>
+          </div>
+        </Link>
+      </div>
+    </Card>
+  );
+}
+
+async function fetchProTemplates(): Promise<{
+  templates: ProTemplate[];
+  error: string | null;
+}> {
+  try {
+    const response = await proTemplatesApi.getAll({
+      page_size: 50,
+      sort_by: "is_featured",
+      sort_order: "desc",
+    });
+    const templates = (response.items ?? []).filter((t) => t.is_active);
+    return { templates, error: null };
+  } catch (err) {
+    console.error("[templates] failed to fetch pro catalog:", err);
+    return {
+      templates: [],
+      error:
+        err instanceof Error ? err.message : "Failed to load Pro templates",
+    };
+  }
+}
+
+export default async function TemplatesPage() {
+  const { templates: proTemplates, error: proError } =
+    await fetchProTemplates();
+
+  const totalCount = staticTemplates.length + proTemplates.length;
+  const freeCount =
+    staticTemplates.length + proTemplates.filter((t) => t.is_free).length;
 
   return (
     <div className="container py-8 md:py-12 lg:py-16">
@@ -257,17 +430,13 @@ export default function TemplatesPage() {
         {/* Stats */}
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 mb-12">
           <div className="text-center space-y-2">
-            <div className="text-2xl font-bold text-primary">
-              {templates.length}
-            </div>
+            <div className="text-2xl font-bold text-primary">{totalCount}</div>
             <div className="text-sm text-muted-foreground">
               Templates Available
             </div>
           </div>
           <div className="text-center space-y-2">
-            <div className="text-2xl font-bold text-primary">
-              {freeTemplates.length}
-            </div>
+            <div className="text-2xl font-bold text-primary">{freeCount}</div>
             <div className="text-sm text-muted-foreground">Free Templates</div>
           </div>
           <div className="text-center space-y-2">
@@ -278,22 +447,63 @@ export default function TemplatesPage() {
           </div>
         </div>
 
-        {/* Free Templates */}
-        {freeTemplates.length > 0 && (
+        {/* Free Templates (local) */}
+        {staticTemplates.length > 0 && (
           <div className="mb-16">
             <h2 className="text-2xl font-bold mb-6">Free Templates</h2>
             <div className="space-y-8">
-              {freeTemplates.map((template) => (
-                <TemplateCard key={template.id} template={template} />
+              {staticTemplates.map((template) => (
+                <StaticTemplateCard key={template.id} template={template} />
               ))}
             </div>
+          </div>
+        )}
+
+        {/* Pro Catalog (live from pro.ruixen.com) */}
+        {proTemplates.length > 0 && (
+          <div className="mb-16">
+            <div className="mb-6 flex items-end justify-between gap-4">
+              <div>
+                <h2 className="text-2xl font-bold">Premium Templates</h2>
+                <p className="text-sm text-muted-foreground mt-1">
+                  Production-ready templates from{" "}
+                  <Link
+                    href="https://pro.ruixen.com?ref=oss_templates"
+                    target="_blank"
+                    className="underline underline-offset-4 hover:text-foreground"
+                  >
+                    Ruixen Pro
+                  </Link>
+                  .
+                </p>
+              </div>
+            </div>
+            <div className="space-y-8">
+              {proTemplates.map((template) => (
+                <ProTemplateCard key={template.id} template={template} />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {proError && proTemplates.length === 0 && (
+          <div className="mb-16 rounded-lg border border-destructive/30 bg-destructive/5 p-6 text-sm text-muted-foreground">
+            We couldn&apos;t load the Pro catalog right now. Browse all
+            templates directly at{" "}
+            <Link
+              href="https://pro.ruixen.com/templates?ref=oss_templates_error"
+              target="_blank"
+              className="underline underline-offset-4 hover:text-foreground"
+            >
+              pro.ruixen.com/templates
+            </Link>
+            .
           </div>
         )}
 
         {/* Pro Templates CTA */}
         <div className="relative py-16 md:py-24">
           <div className="mx-auto max-w-xl text-center">
-            {/* Thin separator */}
             <div className="mx-auto mb-10 h-px w-10 bg-foreground/15" />
 
             <p className="text-[11px] font-medium uppercase tracking-[0.2em] text-muted-foreground/50 mb-5">
@@ -311,7 +521,6 @@ export default function TemplatesPage() {
               updates included.
             </p>
 
-            {/* Price */}
             <div className="mt-7 flex items-baseline justify-center gap-1.5">
               <span className="text-3xl font-[580] tracking-tight text-foreground">
                 $59
@@ -319,7 +528,6 @@ export default function TemplatesPage() {
               <span className="text-sm text-muted-foreground/50">one-time</span>
             </div>
 
-            {/* CTA Buttons */}
             <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-3">
               <Link
                 href="https://pro.ruixen.com/pricing?ref=oss_templates_footer"
@@ -340,7 +548,6 @@ export default function TemplatesPage() {
               </Link>
             </div>
 
-            {/* Thin separator */}
             <div className="mx-auto mt-10 h-px w-10 bg-foreground/15" />
           </div>
         </div>

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -23,8 +23,9 @@ import { siteConfig } from "@/config/site";
 import { cn } from "@/lib/utils";
 import { SidebarNavItem } from "@/types";
 
-export function MobileNav() {
+export function MobileNav({ sidebarNav }: { sidebarNav?: SidebarNavItem[] }) {
   const [isOpen, setIsOpen] = React.useState(false);
+  const nav = sidebarNav ?? docsConfig.sidebarNav;
   return (
     <Sheet open={isOpen} onOpenChange={setIsOpen}>
       <SheetTrigger asChild>
@@ -87,7 +88,7 @@ export function MobileNav() {
             )}
           </div>
           <div className="flex flex-col gap-y-2">
-            {docsConfig.sidebarNav.map((item, index) => (
+            {nav.map((item, index) => (
               <div key={index} className="flex flex-col gap-y-1.5 pt-6">
                 <h4 className="font-medium">
                   {item.title}

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -7,11 +7,13 @@ import { MobileNav } from "@/components/mobile-nav";
 import { ModeToggle } from "@/components/mode-toggle";
 import { buttonVariants } from "@/components/ui/button";
 import { siteConfig } from "@/config/site";
+import { getDocsSidebarNav } from "@/lib/docs-nav";
 import { cn } from "@/lib/utils";
 import Image from "next/image";
 
 export async function SiteHeader() {
   let stars = 300; // Default value
+  const sidebarNav = await getDocsSidebarNav();
 
   try {
     const response = await fetch(
@@ -46,7 +48,7 @@ export async function SiteHeader() {
     >
       <div className="container flex h-16 items-center">
         <MainNav />
-        <MobileNav />
+        <MobileNav sidebarNav={sidebarNav} />
         <div className="flex flex-1 items-center justify-between gap-2 md:justify-end">
           {/* <Link
             className={cn(

--- a/content/docs/mcp.mdx
+++ b/content/docs/mcp.mdx
@@ -37,15 +37,15 @@ Restart your editor after saving. Three Ruixen tools will appear in your assista
 
 ### Where each editor stores its config
 
-| Editor          | Where to put the config |
-|-----------------|--------------------------|
-| **Cursor**      | Settings → Features → Model Context Protocol → **Add new MCP server**, or edit `~/.cursor/mcp.json` directly |
+| Editor             | Where to put the config                                                                                                             |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| **Cursor**         | Settings → Features → Model Context Protocol → **Add new MCP server**, or edit `~/.cursor/mcp.json` directly                        |
 | **Claude Desktop** | `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) · `%APPDATA%\Claude\claude_desktop_config.json` (Windows) |
-| **Claude Code** | Run `claude mcp add ruixen-mcp -- npx -y @ruixen/mcp@latest` |
-| **Windsurf**    | Cascade panel → MCP servers → **Add server** |
-| **Cline**       | MCP Servers tab in the Cline extension panel → **Configure MCP Servers** |
-| **Roo Code**    | MCP Servers tab in the Roo Code extension panel |
-| **VS Code**     | Depends on the MCP extension you use — consult its docs |
+| **Claude Code**    | Run `claude mcp add ruixen-mcp -- npx -y @ruixen/mcp@latest`                                                                        |
+| **Windsurf**       | Cascade panel → MCP servers → **Add server**                                                                                        |
+| **Cline**          | MCP Servers tab in the Cline extension panel → **Configure MCP Servers**                                                            |
+| **Roo Code**       | MCP Servers tab in the Roo Code extension panel                                                                                     |
+| **VS Code**        | Depends on the MCP extension you use — consult its docs                                                                             |
 
 If your editor prefers a one-line command, point it at `npx -y @ruixen/mcp@latest`. That's the entire server — no separate install step, no global package.
 
@@ -75,11 +75,11 @@ Your assistant calls the MCP tools behind the scenes, finds matching components,
 
 Three tools, intentionally small. Most MCP-aware editors cap how many tools a single server can register; this keeps Ruixen well under every cap.
 
-| Tool                   | What it does |
-|------------------------|--------------|
-| `listRegistryItems`    | Browse the full registry with optional filters for `kind`, `query`, and pagination. |
-| `searchRegistryItems`  | Ranked keyword search across names, titles, descriptions, and registry types. |
-| `getRegistryItem`      | Full detail for a single component — install command, source code, related examples, and dependencies. |
+| Tool                  | What it does                                                                                           |
+| --------------------- | ------------------------------------------------------------------------------------------------------ |
+| `listRegistryItems`   | Browse the full registry with optional filters for `kind`, `query`, and pagination.                    |
+| `searchRegistryItems` | Ranked keyword search across names, titles, descriptions, and registry types.                          |
+| `getRegistryItem`     | Full detail for a single component — install command, source code, related examples, and dependencies. |
 
 ## How it works
 

--- a/env.mjs
+++ b/env.mjs
@@ -14,6 +14,8 @@ export const env = createEnv({
    */
   client: {
     NEXT_PUBLIC_APP_URL: z.string().min(1),
+    NEXT_PUBLIC_PRO_API_URL: z.string().url().optional(),
+    NEXT_PUBLIC_PRO_SITE_URL: z.string().url().optional(),
   },
 
   /*
@@ -24,5 +26,7 @@ export const env = createEnv({
    */
   runtimeEnv: {
     NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
+    NEXT_PUBLIC_PRO_API_URL: process.env.NEXT_PUBLIC_PRO_API_URL,
+    NEXT_PUBLIC_PRO_SITE_URL: process.env.NEXT_PUBLIC_PRO_SITE_URL,
   },
 });

--- a/lib/docs-nav.ts
+++ b/lib/docs-nav.ts
@@ -1,0 +1,66 @@
+import type { SidebarNavItem } from "@/types";
+
+import { docsConfig } from "@/config/docs";
+import { proTemplatesApi } from "@/lib/pro-api";
+
+const TEMPLATES_SECTION_TITLE = "Templates";
+
+/**
+ * Trim the marketing subtitle from a Pro template name so it fits the
+ * narrow docs sidebar. The Pro catalog stores names like
+ * "Nguyen – AI Workspace SaaS Landing Page"; the sidebar only needs
+ * "Nguyen". We split on em-dash, en-dash, spaced hyphen, or colon.
+ */
+function shortenTemplateTitle(name: string): string {
+  const match = name.match(/\s+[–—-]\s+|:\s+/);
+  if (match && match.index !== undefined && match.index > 0) {
+    return name.slice(0, match.index).trim();
+  }
+  return name.trim();
+}
+
+/**
+ * Returns the docs sidebar config with Pro catalog entries merged into the
+ * "Templates" section. Each Pro template renders as an internal docs link
+ * to `/docs/templates/<slug>` (served by the unified dynamic route) with
+ * a "Pro" pill badge.
+ *
+ * Called from server components only. Multiple call sites in the same
+ * request share Next.js's fetch cache, so the catalog is fetched at most
+ * once per render.
+ *
+ * Failure mode: if the Pro backend is unreachable, the static config is
+ * returned unchanged so the sidebar never breaks.
+ */
+export async function getDocsSidebarNav(): Promise<SidebarNavItem[]> {
+  let proItems: SidebarNavItem[] = [];
+
+  try {
+    const response = await proTemplatesApi.getAll({
+      page_size: 50,
+      sort_by: "is_featured",
+      sort_order: "desc",
+    });
+    proItems = (response.items ?? [])
+      .filter((template) => template.is_active)
+      .map<SidebarNavItem>((template) => ({
+        title: shortenTemplateTitle(template.name),
+        href: `/docs/templates/${template.slug}`,
+        items: [],
+        paid: true,
+        event: "pro_nav_clicked",
+      }));
+  } catch (error) {
+    console.error("[docs-nav] failed to fetch Pro catalog:", error);
+  }
+
+  if (proItems.length === 0) return docsConfig.sidebarNav;
+
+  return docsConfig.sidebarNav.map((section) => {
+    if (section.title !== TEMPLATES_SECTION_TITLE) return section;
+    return {
+      ...section,
+      items: [...(section.items ?? []), ...proItems],
+    };
+  });
+}

--- a/lib/pro-api.ts
+++ b/lib/pro-api.ts
@@ -1,0 +1,152 @@
+/**
+ * Read-only client for the pro.ruixen.com backend template catalog.
+ *
+ * Mirrors the templatesApi client in pro.ruixen.com/frontend/apps/www/lib/api.ts
+ * but strips everything that requires auth (cart, purchase, download, reviews).
+ * The OSS site only reads the public product list and renders it with links
+ * back to pro.ruixen.com.
+ */
+
+import type {
+  ProCategory,
+  ProductType,
+  ProTemplate,
+  ProTemplateList,
+} from "@/types/pro-templates";
+
+const DEFAULT_PRO_API_URL = "https://pro.ruixen.com/api/v1";
+const DEFAULT_PRO_SITE_URL = "https://pro.ruixen.com";
+
+export const PRO_SITE_URL = (
+  process.env.NEXT_PUBLIC_PRO_SITE_URL || DEFAULT_PRO_SITE_URL
+).replace(/\/$/, "");
+
+const API_BASE_URL = (
+  process.env.NEXT_PUBLIC_PRO_API_URL || DEFAULT_PRO_API_URL
+).replace(/\/$/, "");
+
+export class ProApiError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.status = status;
+    this.name = "ProApiError";
+  }
+}
+
+async function handleResponse<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    const error = await response
+      .json()
+      .catch(() => ({ detail: "An error occurred" }));
+    throw new ProApiError(error.detail || "Request failed", response.status);
+  }
+  return response.json() as Promise<T>;
+}
+
+interface GetTemplatesParams {
+  search?: string;
+  category_id?: number;
+  product_type?: ProductType;
+  tech_stack?: string;
+  is_free?: boolean;
+  is_featured?: boolean;
+  sort_by?: string;
+  sort_order?: string;
+  page?: number;
+  page_size?: number;
+  /** Next.js fetch revalidate window in seconds. Default: 5 minutes. */
+  revalidate?: number;
+}
+
+function buildSearchParams(params?: GetTemplatesParams): string {
+  if (!params) return "";
+  const search = new URLSearchParams();
+  if (params.search) search.set("search", params.search);
+  if (params.category_id !== undefined)
+    search.set("category_id", String(params.category_id));
+  if (params.product_type) search.set("product_type", params.product_type);
+  if (params.tech_stack) search.set("tech_stack", params.tech_stack);
+  if (params.is_free !== undefined)
+    search.set("is_free", String(params.is_free));
+  if (params.is_featured !== undefined)
+    search.set("is_featured", String(params.is_featured));
+  if (params.sort_by) search.set("sort_by", params.sort_by);
+  if (params.sort_order) search.set("sort_order", params.sort_order);
+  if (params.page) search.set("page", String(params.page));
+  if (params.page_size) search.set("page_size", String(params.page_size));
+  const qs = search.toString();
+  return qs ? `?${qs}` : "";
+}
+
+export const proTemplatesApi = {
+  async getAll(params?: GetTemplatesParams): Promise<ProTemplateList> {
+    const url = `${API_BASE_URL}/products${buildSearchParams(params)}`;
+    const response = await fetch(url, {
+      next: { revalidate: params?.revalidate ?? 300 },
+    });
+    return handleResponse<ProTemplateList>(response);
+  },
+
+  async getFeatured(limit = 10): Promise<ProTemplate[]> {
+    const response = await fetch(
+      `${API_BASE_URL}/products/featured?limit=${limit}`,
+      { next: { revalidate: 300 } },
+    );
+    return handleResponse<ProTemplate[]>(response);
+  },
+
+  async getBySlug(slug: string): Promise<ProTemplate> {
+    const response = await fetch(`${API_BASE_URL}/products/${slug}`, {
+      next: { revalidate: 300 },
+    });
+    return handleResponse<ProTemplate>(response);
+  },
+
+  async getCategories(): Promise<ProCategory[]> {
+    const response = await fetch(`${API_BASE_URL}/products/categories`, {
+      next: { revalidate: 600 },
+    });
+    return handleResponse<ProCategory[]>(response);
+  },
+};
+
+/**
+ * Build a deep link to the template detail page on pro.ruixen.com with
+ * UTM/ref attribution so PostHog can follow the OSS → Pro funnel.
+ */
+export function buildProTemplateUrl(
+  slug: string,
+  surface:
+    | "oss_templates"
+    | "oss_templates_get_pro"
+    | "oss_templates_preview"
+    | "oss_templates_footer"
+    | "oss_docs_sidebar" = "oss_templates",
+): string {
+  const base = `${PRO_SITE_URL}/templates/${encodeURIComponent(slug)}`;
+  try {
+    const url = new URL(base);
+    url.searchParams.set("ref", surface);
+    url.searchParams.set("utm_source", "ruixen");
+    url.searchParams.set("utm_medium", "template_card");
+    url.searchParams.set("utm_campaign", "bridge");
+    url.searchParams.set("slug", slug);
+    return url.toString();
+  } catch {
+    return base;
+  }
+}
+
+export function formatUsdFromCents(cents: number): string {
+  if (!Number.isFinite(cents) || cents <= 0) return "Free";
+  const dollars = cents / 100;
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: dollars % 1 === 0 ? 0 : 2,
+  }).format(dollars);
+}
+
+export { API_BASE_URL as PRO_API_BASE_URL };

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -45,7 +45,7 @@ const nextConfig = {
         source: "/docs/:path*.md",
         destination: "/llm/:path*",
       },
-    ]
+    ];
   },
   async headers() {
     return [
@@ -66,6 +66,9 @@ const nextConfig = {
               // posthog.capture() call is blocked by the browser.
               "connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://us.i.posthog.com https://us-assets.i.posthog.com",
               "img-src 'self' data: blob: https:",
+              // Pro template previews (r2.dev) need media-src to load.
+              // Without this, media falls back to default-src 'self'.
+              "media-src 'self' blob: https:",
               "style-src 'self' 'unsafe-inline'",
               "font-src 'self' data:",
               "frame-src 'self'",

--- a/types/pro-templates.ts
+++ b/types/pro-templates.ts
@@ -1,0 +1,94 @@
+/**
+ * Types mirroring the pro.ruixen.com backend Product schema.
+ * Source: pro.ruixen.com/backend/schemas/product.py (ProductResponse).
+ *
+ * These templates are fetched from the Pro catalog and surfaced on the
+ * OSS marketing site. Any purchase, download, or details flow happens on
+ * pro.ruixen.com — we only render metadata here.
+ */
+
+export type ProductType =
+  | "template"
+  | "component"
+  | "icon_pack"
+  | "illustration";
+
+export type TechStack =
+  | "react"
+  | "nextjs"
+  | "vue"
+  | "angular"
+  | "html_css"
+  | "tailwind"
+  | "tailwindcss"
+  | "figma"
+  | "flutter"
+  | "react_native"
+  | "typescript"
+  | "radix-ui"
+  | "shadcn-ui"
+  | "framer-motion"
+  | "react-hook-form"
+  | "zod"
+  | string;
+
+export interface ProCategory {
+  id: number;
+  name: string;
+  slug: string;
+  description?: string | null;
+  icon?: string | null;
+  display_order: number;
+  is_active: boolean;
+  product_count?: number | null;
+}
+
+export interface ProProductImage {
+  id: number;
+  image_url: string;
+  alt_text?: string | null;
+  display_order: number;
+  is_thumbnail: boolean;
+}
+
+export interface ProTemplate {
+  id: number;
+  name: string;
+  slug: string;
+  short_description: string;
+  long_description?: string | null;
+  features?: string[] | null;
+  product_type: ProductType;
+  category?: ProCategory | null;
+  tech_stack?: TechStack[] | null;
+  price_usd_cents: number;
+  is_free: boolean;
+  is_included_in_membership: boolean;
+  demo_url?: string | null;
+  video_url_light?: string | null;
+  video_url_dark?: string | null;
+  preview_url?: string | null;
+  documentation_url?: string | null;
+  what_is_this?: string | null;
+  who_is_this_for?: string | null;
+  highlights?: string[] | null;
+  sections_included?: string[] | null;
+  dependencies?: Record<string, string> | null;
+  is_active: boolean;
+  is_featured: boolean;
+  coming_soon: boolean;
+  download_count: number;
+  view_count: number;
+  version?: string | null;
+  images: ProProductImage[];
+  created_timestamp?: string | null;
+  updated_timestamp?: string | null;
+}
+
+export interface ProTemplateList {
+  items: ProTemplate[];
+  total: number;
+  page: number;
+  page_size: number;
+  total_pages: number;
+}


### PR DESCRIPTION
## Summary
Bridges the OSS marketing site to the Pro template catalog so visitors can discover paid templates without leaving ruixen.com, then deep-link to pro.ruixen.com with UTM-attributed CTAs for the purchase flow.

- **Read-only Pro API client** — `lib/pro-api.ts` mirrors the subset of `pro.ruixen.com`'s backend that the OSS site needs (list / featured / by-slug / categories). No auth, cart, or purchase — those stay on pro.ruixen.com. Includes `buildProTemplateUrl` with UTM/ref params so PostHog can follow the OSS → Pro funnel, and `formatUsdFromCents` for consistent price rendering.
- **Type mirror** — `types/pro-templates.ts` mirrors the Pro backend `ProductResponse` schema.
- **Sidebar injection** — `lib/docs-nav.ts` merges live Pro catalog entries into the docs "Templates" section as internal `/docs/templates/<slug>` links. Graceful fallback to static config if the Pro backend is unreachable.
- **Nav wiring** — docs layout is now async and resolves the merged sidebar server-side; `SiteHeader` fetches once and forwards to `MobileNav` so mobile shows the same list.
- **Unified template route** — `/docs/templates/[slug]` serves a hand-authored MDX page if one exists, otherwise falls back to a live-fetched Pro detail page with gallery, tech stack, price, and a deep link to pro.ruixen.com.
- **`/templates` marketing page** — rebuilt as a live grid of Pro templates with UTM-attributed CTAs.
- **Infra** — `env.mjs` declares `NEXT_PUBLIC_PRO_API_URL` / `NEXT_PUBLIC_PRO_SITE_URL` (both optional, fall back to pro.ruixen.com). `next.config.mjs` adds `media-src` to the CSP so r2.dev-hosted video previews load.
- **Format fix** — includes a one-commit chore to format `content/docs/mcp.mdx` so CI's `format:check` passes. Same fix is also in #71; whichever merges first makes the other a no-op.

## Commit structure
Commits are ordered by dependency so each is individually reviewable:
1. `chore(config)` — env vars + CSP
2. `feat(pro-api)` — types + read-only client
3. `feat(docs-nav)` — sidebar merger
4. `feat(nav)` — wire sidebar through layout + header + mobile nav
5. `feat(templates)` — `/docs/templates/[slug]` + `/templates`
6. `chore(format)` — mcp.mdx prettier fix

## Test plan
- [ ] Set `NEXT_PUBLIC_PRO_API_URL` / `NEXT_PUBLIC_PRO_SITE_URL` (or leave unset to use defaults) and confirm `pnpm dev` renders `/templates` with live catalog data.
- [ ] Docs sidebar (desktop + mobile) shows the "Templates" section with both MDX entries and Pro entries marked with the "Pro" pill.
- [ ] `/docs/templates/<mdx-slug>` renders the MDX page unchanged (TOC, pager, contribute intact).
- [ ] `/docs/templates/<pro-slug>` renders the Pro-fetched detail page with gallery, price, "Get on Pro" CTA.
- [ ] Template card clicks hit pro.ruixen.com with `?ref=`, `utm_source=ruixen`, `utm_medium=template_card`, `utm_campaign=bridge` query params.
- [ ] Pro catalog video previews (r2.dev) load without CSP console errors.
- [ ] With the Pro backend unreachable, docs sidebar still renders (fallback to static config); `/templates` degrades gracefully.
- [ ] CI: `pnpm lint`, `pnpm format:check`, `pnpm typecheck` all pass.