### PR TITLE
fix(docs): scroll TOC independently, pin Pro CTA to sidebar bottom

### DIFF
--- a/app/(docs)/docs/[[...slug]]/page.tsx
+++ b/app/(docs)/docs/[[...slug]]/page.tsx
@@ -188,12 +188,16 @@ export default async function DocPage({ params }: DocPageProps) {
         <DocPager doc={doc} />
       </div>
       {doc.toc && (
-        <div className="hidden py-6 pl-6 text-sm xl:block">
-          <div className="sticky top-[90px] h-[calc(100vh-3.5rem)] space-y-4">
-            <TableOfContents toc={toc} />
-            <div id="dynamic-toc" />
-            <Contribute doc={doc} />
-            <SidebarCTA />
+        <div className="hidden pl-6 text-sm xl:block">
+          <div className="sticky top-16 flex h-[calc(100vh-4rem)] flex-col py-6">
+            <div className="flex-1 min-h-0 space-y-4 overflow-y-auto pr-2">
+              <TableOfContents toc={toc} />
+              <div id="dynamic-toc" />
+            </div>
+            <div className="shrink-0 space-y-4 pr-2 pt-6">
+              <Contribute doc={doc} />
+              <SidebarCTA />
+            </div>
           </div>
         </div>
       )}

--- a/app/(docs)/docs/templates/[slug]/page.tsx
+++ b/app/(docs)/docs/templates/[slug]/page.tsx
@@ -165,12 +165,16 @@ async function MdxDocView({ doc }: { doc: Doc }) {
         <DocPager doc={doc} />
       </div>
       {doc.toc && (
-        <div className="hidden py-6 pl-6 text-sm xl:block">
-          <div className="sticky top-[90px] h-[calc(100vh-3.5rem)] space-y-4">
-            <TableOfContents toc={toc} />
-            <div id="dynamic-toc" />
-            <Contribute doc={doc} />
-            <SidebarCTA />
+        <div className="hidden pl-6 text-sm xl:block">
+          <div className="sticky top-16 flex h-[calc(100vh-4rem)] flex-col py-6">
+            <div className="flex-1 min-h-0 space-y-4 overflow-y-auto pr-2">
+              <TableOfContents toc={toc} />
+              <div id="dynamic-toc" />
+            </div>
+            <div className="shrink-0 space-y-4 pr-2 pt-6">
+              <Contribute doc={doc} />
+              <SidebarCTA />
+            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
The docs right rail was falling off the page on long-TOC docs (e.g. \`/docs/components\` with 23 categories) — the Pro CTA was rendered below the fold and the TOC didn't scroll.

**Two compounding bugs:**
1. **Geometry mismatch** — sticky container had \`top-[90px]\` paired with \`h-[calc(100vh-3.5rem)]\`. Header is \`h-16\` (4rem = 64px), not 3.5rem, and 90 ≠ 64 — so the container was ~34px taller than the available viewport below the header and its bottom already spilled off the fold before any content was placed.
2. **No scroll region** — the inner container used \`space-y-4\` with children in natural flow. Once TOC grew past the available height, Contribute + SidebarCTA were pushed below the viewport and effectively unreachable.

**Fix:** restructure the sticky container as a flex column that exactly fills the viewport below the header.
- \`sticky top-16 h-[calc(100vh-4rem)] flex flex-col\` — geometry now matches the header exactly.
- TOC + \`#dynamic-toc\` live in a \`flex-1 min-h-0 overflow-y-auto\` region. \`min-h-0\` is required for a flex child to shrink below its content size so \`overflow-y: auto\` actually engages.
- Contribute + SidebarCTA live in a \`shrink-0\` block anchored at the bottom.

Applied to **both** places that carried the identical broken pattern:
- \`app/(docs)/docs/[[...slug]]/page.tsx\` — component docs, MCP page, installation guides, etc.
- \`app/(docs)/docs/templates/[slug]/page.tsx\` — template docs.

## Test plan
- [ ] Open \`/docs/components\` (long TOC) — Pro CTA visible at sidebar bottom, TOC scrolls independently without moving the main content.
- [ ] Open a short-TOC doc like \`/docs/installation\` — TOC sits at top naturally, CTA still at bottom, no weird whitespace.
- [ ] Open a template doc at \`/docs/templates/portfolio\` — same behavior as component docs.
- [ ] Scroll the main content — sidebar stays pinned at the exact top of the viewport below the header (no 34px overhang).
- [ ] Short viewport (~700px tall) — TOC still scrolls; CTA remains visible.
- [ ] CI gates: \`format:check\`, \`lint\`, \`typecheck\` — all pass locally.