### PR TITLE
Hardcode Pro catalog, drop API fetch, polish sidebar labels

### DIFF
--- a/app/(docs)/docs/[[...slug]]/page.tsx
+++ b/app/(docs)/docs/[[...slug]]/page.tsx
@@ -190,12 +190,15 @@ export default async function DocPage({ params }: DocPageProps) {
       {doc.toc && (
         <div className="hidden pl-6 text-sm xl:block">
           <div className="sticky top-16 flex h-[calc(100vh-4rem)] flex-col py-6">
-            <div className="flex-1 min-h-0 space-y-4 overflow-y-auto pr-2">
+            {/* Scrollable: TOC + Contribute. Contribute scrolls with the TOC
+                so the CTA below has enough room to sit at the sidebar bottom. */}
+            <div className="flex-1 min-h-0 space-y-6 overflow-y-auto pr-2">
               <TableOfContents toc={toc} />
               <div id="dynamic-toc" />
-            </div>
-            <div className="shrink-0 space-y-4 pr-2 pt-6">
               <Contribute doc={doc} />
+            </div>
+            {/* Pinned at the sidebar bottom. */}
+            <div className="shrink-0 pr-2 pt-4">
               <SidebarCTA />
             </div>
           </div>

--- a/app/(docs)/docs/templates/[slug]/page.tsx
+++ b/app/(docs)/docs/templates/[slug]/page.tsx
@@ -14,16 +14,11 @@ import { SidebarCTA } from "@/components/sidebar-cta";
 import { TableOfContents } from "@/components/toc";
 import { Badge, badgeVariants } from "@/components/ui/badge";
 import { buttonVariants } from "@/components/ui/button";
-import {
-  buildProTemplateUrl,
-  formatUsdFromCents,
-  proTemplatesApi,
-} from "@/lib/pro-api";
+import { buildProTemplateUrl, formatUsdFromCents } from "@/lib/pro-api";
+import { getProTemplateBySlug } from "@/data/pro-catalog";
 import { getTableOfContents } from "@/lib/toc";
 import { absoluteUrl, cn } from "@/lib/utils";
 import type { ProTemplate } from "@/types/pro-templates";
-
-export const revalidate = 300;
 
 interface PageProps {
   params: Promise<{ slug: string }>;
@@ -43,13 +38,9 @@ async function resolveTemplate(
   );
   if (mdxDoc) return { kind: "mdx", doc: mdxDoc };
 
-  try {
-    const template = await proTemplatesApi.getBySlug(slug);
-    if (!template.is_active) return null;
-    return { kind: "pro", template };
-  } catch {
-    return null;
-  }
+  const template = getProTemplateBySlug(slug);
+  if (!template) return null;
+  return { kind: "pro", template };
 }
 
 export async function generateMetadata({
@@ -167,12 +158,15 @@ async function MdxDocView({ doc }: { doc: Doc }) {
       {doc.toc && (
         <div className="hidden pl-6 text-sm xl:block">
           <div className="sticky top-16 flex h-[calc(100vh-4rem)] flex-col py-6">
-            <div className="flex-1 min-h-0 space-y-4 overflow-y-auto pr-2">
+            {/* Scrollable: TOC + Contribute. Contribute scrolls with the TOC
+                so the CTA below has enough room to sit at the sidebar bottom. */}
+            <div className="flex-1 min-h-0 space-y-6 overflow-y-auto pr-2">
               <TableOfContents toc={toc} />
               <div id="dynamic-toc" />
-            </div>
-            <div className="shrink-0 space-y-4 pr-2 pt-6">
               <Contribute doc={doc} />
+            </div>
+            {/* Pinned at the sidebar bottom. */}
+            <div className="shrink-0 pr-2 pt-4">
               <SidebarCTA />
             </div>
           </div>
@@ -214,14 +208,11 @@ function ProTemplateView({ template }: { template: ProTemplate }) {
   const priceLabel = template.is_free
     ? "Free"
     : formatUsdFromCents(template.price_usd_cents);
-  const proDetailHref = buildProTemplateUrl(template.slug, "oss_docs_sidebar");
-  const getAccessHref = buildProTemplateUrl(
-    template.slug,
-    "oss_templates_get_pro",
-  );
+  const proDetailHref = buildProTemplateUrl(template.slug);
+  const getAccessHref = buildProTemplateUrl(template.slug);
   const previewHref = template.demo_url
     ? template.demo_url
-    : buildProTemplateUrl(template.slug, "oss_templates_preview");
+    : buildProTemplateUrl(template.slug);
 
   return (
     <main className="relative">

--- a/app/templates/page.tsx
+++ b/app/templates/page.tsx
@@ -8,11 +8,8 @@ import {
 } from "@radix-ui/react-icons";
 
 import type { ProTemplate } from "@/types/pro-templates";
-import {
-  buildProTemplateUrl,
-  formatUsdFromCents,
-  proTemplatesApi,
-} from "@/lib/pro-api";
+import { COMING_SOON_CATALOG, getProTemplates } from "@/data/pro-catalog";
+import { buildProTemplateUrl, formatUsdFromCents } from "@/lib/pro-api";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -23,8 +20,7 @@ import {
 } from "@/components/ui/card";
 import { TemplateProClickTracker } from "@/components/template-pro-click-tracker";
 
-// Pro catalog lives on pro.ruixen.com and is cached at the edge for 5 minutes.
-export const revalidate = 300;
+// Pro catalog is hardcoded in data/pro-catalog.ts — no runtime fetch.
 
 export const metadata: Metadata = {
   title: "Templates",
@@ -226,14 +222,11 @@ function ProTemplateCard({ template }: { template: ProTemplate }) {
   const priceLabel = template.is_free
     ? "Free"
     : formatUsdFromCents(template.price_usd_cents);
-  const detailHref = buildProTemplateUrl(template.slug, "oss_templates");
-  const getProHref = buildProTemplateUrl(
-    template.slug,
-    "oss_templates_get_pro",
-  );
+  const detailHref = buildProTemplateUrl(template.slug);
+  const getProHref = buildProTemplateUrl(template.slug);
   const previewHref = template.demo_url
     ? template.demo_url
-    : buildProTemplateUrl(template.slug, "oss_templates_preview");
+    : buildProTemplateUrl(template.slug);
 
   return (
     <Card className="overflow-hidden transition-all duration-300 shadow-none border-0">
@@ -381,33 +374,65 @@ function ProTemplateCard({ template }: { template: ProTemplate }) {
   );
 }
 
-async function fetchProTemplates(): Promise<{
-  templates: ProTemplate[];
-  error: string | null;
-}> {
-  try {
-    const response = await proTemplatesApi.getAll({
-      page_size: 50,
-      sort_by: "is_featured",
-      sort_order: "desc",
-    });
-    const templates = (response.items ?? []).filter((t) => t.is_active);
-    return { templates, error: null };
-  } catch (err) {
-    console.error("[templates] failed to fetch pro catalog:", err);
-    return {
-      templates: [],
-      error:
-        err instanceof Error ? err.message : "Failed to load Pro templates",
-    };
-  }
+function ComingSoonTemplateCard({
+  name,
+  description,
+  imageUrl,
+}: {
+  name: string;
+  description: string;
+  imageUrl: string;
+}) {
+  return (
+    <Card className="overflow-hidden opacity-75 shadow-none border-0">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-center">
+        <div className="p-6 space-y-4">
+          <Badge
+            variant="outline"
+            className="gap-1 bg-amber-500/10 text-amber-600 border-amber-500/20 dark:text-amber-400"
+          >
+            Coming Soon
+          </Badge>
+          <CardHeader className="p-0">
+            <CardTitle className="text-2xl text-muted-foreground">
+              {name}
+            </CardTitle>
+            <CardDescription className="text-muted-foreground/70">
+              {description}
+            </CardDescription>
+          </CardHeader>
+          <div className="inline-flex h-10 items-center justify-center rounded-md bg-muted px-4 text-sm font-medium text-muted-foreground">
+            Available Soon
+          </div>
+        </div>
+        <div className="relative rounded-3xl overflow-hidden">
+          <Image
+            src={imageUrl}
+            alt={name}
+            width={1200}
+            height={800}
+            className="w-full h-[26rem] rounded-3xl object-cover object-top grayscale-[30%]"
+            unoptimized
+          />
+          <div className="absolute inset-0 flex items-center justify-center bg-background/40 backdrop-blur-[2px] rounded-3xl">
+            <div className="rounded-full bg-background/80 px-4 py-2 text-sm font-medium text-muted-foreground shadow-sm">
+              Coming Very Soon
+            </div>
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
 }
 
-export default async function TemplatesPage() {
-  const { templates: proTemplates, error: proError } =
-    await fetchProTemplates();
+export default function TemplatesPage() {
+  const proTemplates: ProTemplate[] = getProTemplates()
+    .slice()
+    .sort((a, b) => Number(b.is_featured) - Number(a.is_featured));
+  const comingSoonTemplates = COMING_SOON_CATALOG;
 
-  const totalCount = staticTemplates.length + proTemplates.length;
+  const totalCount =
+    staticTemplates.length + proTemplates.length + comingSoonTemplates.length;
   const freeCount =
     staticTemplates.length + proTemplates.filter((t) => t.is_free).length;
 
@@ -482,22 +507,15 @@ export default async function TemplatesPage() {
               {proTemplates.map((template) => (
                 <ProTemplateCard key={template.id} template={template} />
               ))}
+              {comingSoonTemplates.map((template) => (
+                <ComingSoonTemplateCard
+                  key={template.name}
+                  name={template.name}
+                  description={template.description}
+                  imageUrl={template.image_url}
+                />
+              ))}
             </div>
-          </div>
-        )}
-
-        {proError && proTemplates.length === 0 && (
-          <div className="mb-16 rounded-lg border border-destructive/30 bg-destructive/5 p-6 text-sm text-muted-foreground">
-            We couldn&apos;t load the Pro catalog right now. Browse all
-            templates directly at{" "}
-            <Link
-              href="https://pro.ruixen.com/templates?ref=oss_templates_error"
-              target="_blank"
-              className="underline underline-offset-4 hover:text-foreground"
-            >
-              pro.ruixen.com/templates
-            </Link>
-            .
           </div>
         )}
 

--- a/components/sidebar-nav.tsx
+++ b/components/sidebar-nav.tsx
@@ -105,13 +105,25 @@ export function DocsSidebarNavItems({
               <span className="relative shrink-0">{item.title}</span>
               <div className="flex items-center gap-1">
                 {item.label && (
-                  <span className="rounded-md bg-[var(--color-sidebar-label)] px-1.5 py-0.5 text-[0.7rem] leading-none text-[var(--color-sidebar-label-foreground)]">
+                  <span
+                    className={cn(
+                      "rounded-md px-1.5 py-0.5 text-[0.7rem] leading-none",
+                      item.gold
+                        ? "bg-[#bef853] text-black"
+                        : "bg-[var(--color-sidebar-label)] text-[var(--color-sidebar-label-foreground)]",
+                    )}
+                  >
                     {item.label}
                   </span>
                 )}
                 {item.paid && (
-                  <span className="rounded-md bg-[var(--color-sidebar-label)] px-1.5 py-0.5 text-[0.65rem] leading-none text-[var(--color-sidebar-label-foreground)]">
+                  <span className="rounded-md bg-[#bef853] px-1.5 py-0.5 text-[0.65rem] leading-none text-black">
                     Pro
+                  </span>
+                )}
+                {item.free && (
+                  <span className="rounded-md bg-[#2563eb] px-1.5 py-0.5 text-[0.65rem] leading-none text-white">
+                    Free
                   </span>
                 )}
                 {item.external && <ExternalLinkIcon className="size-3" />}
@@ -246,13 +258,25 @@ function CollapsibleCategory({
                     </span>
                     <div className="flex items-center gap-1 shrink-0">
                       {child.label && (
-                        <span className="rounded-md bg-[var(--color-sidebar-label)] px-1.5 py-0.5 text-[0.65rem] leading-none text-[var(--color-sidebar-label-foreground)]">
+                        <span
+                          className={cn(
+                            "rounded-md px-1.5 py-0.5 text-[0.65rem] leading-none",
+                            child.gold
+                              ? "bg-[#bef853] text-black"
+                              : "bg-[var(--color-sidebar-label)] text-[var(--color-sidebar-label-foreground)]",
+                          )}
+                        >
                           {child.label}
                         </span>
                       )}
                       {child.paid && (
-                        <span className="rounded-md bg-[var(--color-sidebar-label)] px-1.5 py-0.5 text-[0.65rem] leading-none text-[var(--color-sidebar-label-foreground)]">
+                        <span className="rounded-md bg-[#bef853] px-1.5 py-0.5 text-[0.65rem] leading-none text-black">
                           Pro
+                        </span>
+                      )}
+                      {child.free && (
+                        <span className="rounded-md bg-[#2563eb] px-1.5 py-0.5 text-[0.65rem] leading-none text-white">
+                          Free
                         </span>
                       )}
                       {child.external && (

--- a/config/docs.ts
+++ b/config/docs.ts
@@ -126,6 +126,7 @@ export const docsConfig: DocsConfig = {
           href: "/docs/mcp",
           items: [],
           label: "Free",
+          gold: true,
         },
         {
           title: "Dual Tailwind",
@@ -149,6 +150,7 @@ export const docsConfig: DocsConfig = {
           href: `/docs/templates/portfolio`,
           items: [],
           label: "",
+          free: true,
           event: "template_portfolio_clicked",
         },
       ],

--- a/data/pro-catalog.ts
+++ b/data/pro-catalog.ts
@@ -1,0 +1,290 @@
+/**
+ * Pro template catalog — hardcoded mirror of the real pro.ruixen.com catalog.
+ *
+ * Source of truth (both active templates live on pro.ruixen.com):
+ *   - Nguyen   → pro.ruixen.com/backend/scripts/add_nguyen.py
+ *   - Intellune → pulled from the live Pro product detail JSON
+ *                 (pro.ruixen.com/templates/intellune RSC payload)
+ *   - Coming-soon teaser → pro.ruixen.com/frontend/apps/www/app/templates/page.tsx
+ *
+ * The OSS site used to fetch /api/v1/products from pro.ruixen.com at build time.
+ * That endpoint is unreliable, so everything here is static — the templates
+ * page and /docs/templates/<slug> pages never fail to build or show a runtime
+ * error. When pro.ruixen.com ships a new product, update this file.
+ */
+
+import type { ProCategory, ProTemplate } from "@/types/pro-templates";
+
+const LANDING_PAGES: ProCategory = {
+  id: 2,
+  name: "Landing Pages",
+  slug: "landing-pages",
+  description: "Marketing landing pages, SaaS homepages, and product showcases",
+  icon: "rocket",
+  display_order: 2,
+  is_active: true,
+};
+
+const R2_BASE =
+  "https://pub-940ccf6255b54fa799a9b01050e6c227.r2.dev/pro_ruixen_products";
+
+function baseTemplate(overrides: Partial<ProTemplate>): ProTemplate {
+  return {
+    id: 0,
+    name: "",
+    slug: "",
+    short_description: "",
+    long_description: null,
+    features: null,
+    product_type: "template",
+    category: null,
+    tech_stack: null,
+    price_usd_cents: 0,
+    is_free: false,
+    is_included_in_membership: true,
+    demo_url: null,
+    video_url_light: null,
+    video_url_dark: null,
+    preview_url: null,
+    documentation_url: null,
+    what_is_this: null,
+    who_is_this_for: null,
+    highlights: null,
+    sections_included: null,
+    dependencies: null,
+    is_active: true,
+    is_featured: false,
+    coming_soon: false,
+    download_count: 0,
+    view_count: 0,
+    version: null,
+    images: [],
+    created_timestamp: null,
+    updated_timestamp: null,
+    ...overrides,
+  };
+}
+
+export const PRO_CATALOG: ProTemplate[] = [
+  baseTemplate({
+    id: 2,
+    name: "Intellune - AI Agent Platform Template",
+    slug: "intellune",
+    short_description:
+      "Production-ready Next.js 15 template for building AI agent platforms with real-time streaming, modern dashboard UI, and seamless deployment infrastructure.",
+    long_description:
+      "Intellune is a comprehensive Next.js 15 template designed for developers building AI-powered agent platforms. Built with React 19, TypeScript, and Tailwind CSS, this template provides everything you need to launch your AI SaaS product.\n\nThe template features a stunning dark-mode-first design with glass morphism effects, real-time agent streaming capabilities, and a complete dashboard interface. Perfect for AI startups, automation platforms, and developer tools.\n\nIncludes 15+ pre-built sections, authentication flows, pricing pages, and deployment configurations for Vercel and other platforms.",
+    product_type: "template",
+    category: null,
+    tech_stack: [
+      "nextjs",
+      "react",
+      "typescript",
+      "tailwindcss",
+      "radix-ui",
+      "shadcn-ui",
+      "framer-motion",
+      "react-hook-form",
+      "zod",
+    ],
+    features: [
+      "Complete Next.js 15 application with App Router and React 19",
+      "Real-time AI agent streaming interface with typing indicators",
+      "Glass morphism UI design with dark/light mode support",
+      "15+ pre-built responsive sections and components",
+      "Authentication-ready pages (login, signup, forgot password)",
+      "Interactive pricing page with toggle animations",
+      "Dashboard layout with sidebar navigation",
+      "Tailwind CSS with custom animations and effects",
+      "TypeScript for type-safe development",
+      "SEO optimized with meta tags and OpenGraph",
+      "Mobile-first responsive design",
+      "One-click Vercel deployment configuration",
+    ],
+    highlights: [
+      "Next.js 15 with App Router and React 19",
+      "28+ custom UI components with shadcn/ui and Radix UI",
+      "Interactive bento grid feature showcase",
+      "World map visualization for global deployment",
+      "Live chat interface demo component",
+      "Multi-model AI selector with 8+ providers",
+      "Real-time analytics charts with Recharts",
+      "Testimonial carousel with customer stories",
+      "Fully responsive and accessible design",
+      "Dark/light theme with smooth transitions",
+    ],
+    sections_included: [
+      "Animated hero with gradient text",
+      "AI agent chat interface",
+      "Feature showcase bento grid",
+      "Interactive pricing cards",
+      "Testimonials carousel",
+      "Integration partners logo cloud",
+      "Dashboard preview section",
+      "CTA sections with animations",
+      "FAQ accordion",
+      "Newsletter signup",
+      "Footer with sitemap",
+    ],
+    dependencies: {
+      next: "15.5.9",
+      react: "19.0.0",
+      typescript: "5.7.3",
+      tailwindcss: "4.0.4",
+      "framer-motion": "12.15.0",
+      "@radix-ui/react-accordion": "1.2.11",
+      "@radix-ui/react-dialog": "1.1.14",
+      "@radix-ui/react-dropdown-menu": "2.1.15",
+      "@radix-ui/react-tabs": "1.1.12",
+      recharts: "2.15.4",
+      "drizzle-orm": "0.44.2",
+      "@neondatabase/serverless": "1.0.1",
+      "@xyflow/react": "12.6.1",
+      "@dnd-kit/core": "6.3.1",
+      zod: "3.25.34",
+      "react-hook-form": "7.57.0",
+      resend: "4.5.2",
+      "better-auth": "1.2.8",
+    },
+    price_usd_cents: 2900,
+    is_free: false,
+    is_included_in_membership: true,
+    demo_url: "https://intellune-ruixen-com.vercel.app/",
+    preview_url: "https://intellune-ruixen-com.vercel.app/",
+    video_url_light: `${R2_BASE}/intellune-light-video.mp4`,
+    video_url_dark: `${R2_BASE}/intellune-dark-video.mp4`,
+    what_is_this:
+      "Intellune is a production-ready Next.js 15 template specifically designed for AI agent platforms and SaaS products. It combines cutting-edge frontend technologies with a stunning visual design to help you launch your AI product faster.",
+    who_is_this_for:
+      "You're building an AI-powered SaaS product and need a professional frontend that matches the innovation of your technology. Whether you're creating an AI assistant platform, automation tool, or developer API service, Intellune gives you the complete foundation to impress users and investors alike.",
+    is_active: true,
+    is_featured: true,
+    coming_soon: false,
+    version: "1.0.0",
+    images: [
+      {
+        id: 1,
+        image_url: `${R2_BASE}/intellune-light.png`,
+        alt_text: "Intellune AI Agent Platform - Light Theme",
+        display_order: 0,
+        is_thumbnail: true,
+      },
+      {
+        id: 2,
+        image_url: `${R2_BASE}/intellune-dark.png`,
+        alt_text: "Intellune AI Agent Platform - Dark Theme",
+        display_order: 1,
+        is_thumbnail: false,
+      },
+    ],
+  }),
+  baseTemplate({
+    id: 1,
+    name: "Nguyen – AI Workspace SaaS Landing Page",
+    slug: "nguyen-one",
+    short_description:
+      "A modern SaaS landing page for AI-native team workspaces with dark/light mode, interactive visuals, and Framer Motion animations.",
+    long_description:
+      "A fully responsive SaaS landing page template designed for AI-native team platforms. Built with Next.js 15, Tailwind CSS 4, and Framer Motion. Features an animated hero with video dialog, bento-grid feature showcase, interactive AI agent routing visuals, testimonial marquee, tiered pricing with billing toggle, accordion FAQs, and a structured footer — all with polished dark and light themes.",
+    product_type: "template",
+    category: LANDING_PAGES,
+    tech_stack: ["nextjs", "react", "tailwind", "framer-motion"],
+    features: [
+      "Fully responsive design (mobile, tablet, desktop)",
+      "Dark / Light mode with next-themes",
+      "Framer Motion animations and micro-interactions",
+      "Interactive AI agent routing visual with animated SVG paths",
+      "Bento-grid featured section with animated cards",
+      "Testimonial marquee carousel",
+      "Tiered pricing with monthly/annual billing toggle",
+      "Accordion FAQ section",
+      "Hero section with embedded video dialog",
+      "Scroll-to-section navigation",
+    ],
+    highlights: [
+      "Built with Next.js 15 App Router & React 19",
+      "7 hand-crafted sections with rich interactive visuals",
+      "One-click deploy to Vercel",
+    ],
+    sections_included: [
+      "Hero",
+      "Featured (Bento Grid)",
+      "Services (3-row showcase)",
+      "Testimonials",
+      "Pricing",
+      "FAQs",
+      "Footer",
+    ],
+    dependencies: {
+      next: "15.4.10",
+      react: "^19.2.1",
+      motion: "^12.16.0",
+      tailwindcss: "^4",
+      "next-themes": "^0.4.6",
+      "@radix-ui/react-accordion": "^1.2.11",
+      "@radix-ui/react-dialog": "^1.1.14",
+      "@radix-ui/react-navigation-menu": "^1.2.13",
+      "@radix-ui/react-tabs": "^1.1.12",
+      "embla-carousel-react": "^8.6.0",
+      "lucide-react": "^0.513.0",
+    },
+    price_usd_cents: 2900,
+    is_free: false,
+    is_included_in_membership: true,
+    demo_url: "https://nguyen-one.vercel.app/",
+    preview_url: "https://nguyen-one.vercel.app/",
+    video_url_light: `${R2_BASE}/nguyen-one-light.mp4`,
+    video_url_dark: `${R2_BASE}/nguyen-one-dark.mp4`,
+    what_is_this:
+      "A premium SaaS landing page template built for AI-native team workspaces. It showcases AI agent routing, smart mentions, automated workflows, and team collaboration features through polished interactive visuals and animations.",
+    who_is_this_for:
+      "Founders, indie hackers, and SaaS teams building AI-powered products who need a production-ready landing page with pricing, testimonials, and feature showcases out of the box.",
+    is_active: true,
+    is_featured: true,
+    coming_soon: false,
+    version: "1.0.0",
+    images: [
+      {
+        id: 1,
+        image_url: `${R2_BASE}/nguyen-one-light.png`,
+        alt_text: "Nguyen landing page — light theme full preview",
+        display_order: 0,
+        is_thumbnail: true,
+      },
+      {
+        id: 2,
+        image_url: `${R2_BASE}/nguyen-one-dark.png`,
+        alt_text: "Nguyen landing page — dark theme full preview",
+        display_order: 1,
+        is_thumbnail: false,
+      },
+      {
+        id: 3,
+        image_url: `${R2_BASE}/nguyen-one-hero-light.png`,
+        alt_text: "Hero section — light theme",
+        display_order: 2,
+        is_thumbnail: false,
+      },
+    ],
+  }),
+];
+
+export const COMING_SOON_CATALOG = [
+  {
+    name: "Folio – Win More Clients",
+    description:
+      "Turn visitors into clients. A showcase that makes your work impossible to ignore.",
+    image_url: `${R2_BASE}/dummy-02.png`,
+  },
+] as const;
+
+export function getProTemplates(): ProTemplate[] {
+  return PRO_CATALOG.filter((t) => t.is_active && !t.coming_soon);
+}
+
+export function getProTemplateBySlug(slug: string): ProTemplate | null {
+  return (
+    PRO_CATALOG.find((t) => t.slug === slug && t.is_active && !t.coming_soon) ??
+    null
+  );
+}

--- a/lib/docs-nav.ts
+++ b/lib/docs-nav.ts
@@ -1,16 +1,10 @@
 import type { SidebarNavItem } from "@/types";
 
 import { docsConfig } from "@/config/docs";
-import { proTemplatesApi } from "@/lib/pro-api";
+import { COMING_SOON_CATALOG, getProTemplates } from "@/data/pro-catalog";
 
 const TEMPLATES_SECTION_TITLE = "Templates";
 
-/**
- * Trim the marketing subtitle from a Pro template name so it fits the
- * narrow docs sidebar. The Pro catalog stores names like
- * "Nguyen – AI Workspace SaaS Landing Page"; the sidebar only needs
- * "Nguyen". We split on em-dash, en-dash, spaced hyphen, or colon.
- */
 function shortenTemplateTitle(name: string): string {
   const match = name.match(/\s+[–—-]\s+|:\s+/);
   if (match && match.index !== undefined && match.index > 0) {
@@ -19,48 +13,43 @@ function shortenTemplateTitle(name: string): string {
   return name.trim();
 }
 
-/**
- * Returns the docs sidebar config with Pro catalog entries merged into the
- * "Templates" section. Each Pro template renders as an internal docs link
- * to `/docs/templates/<slug>` (served by the unified dynamic route) with
- * a "Pro" pill badge.
- *
- * Called from server components only. Multiple call sites in the same
- * request share Next.js's fetch cache, so the catalog is fetched at most
- * once per render.
- *
- * Failure mode: if the Pro backend is unreachable, the static config is
- * returned unchanged so the sidebar never breaks.
- */
-export async function getDocsSidebarNav(): Promise<SidebarNavItem[]> {
-  let proItems: SidebarNavItem[] = [];
+export function getDocsSidebarNav(): SidebarNavItem[] {
+  const activeItems: SidebarNavItem[] = getProTemplates()
+    .slice()
+    .sort((a, b) => Number(b.is_featured) - Number(a.is_featured))
+    .map<SidebarNavItem>((template) => ({
+      title: shortenTemplateTitle(template.name),
+      href: `/docs/templates/${template.slug}`,
+      items: [],
+      paid: true,
+      event: "pro_nav_clicked",
+    }));
 
-  try {
-    const response = await proTemplatesApi.getAll({
-      page_size: 50,
-      sort_by: "is_featured",
-      sort_order: "desc",
-    });
-    proItems = (response.items ?? [])
-      .filter((template) => template.is_active)
-      .map<SidebarNavItem>((template) => ({
-        title: shortenTemplateTitle(template.name),
-        href: `/docs/templates/${template.slug}`,
-        items: [],
-        paid: true,
-        event: "pro_nav_clicked",
-      }));
-  } catch (error) {
-    console.error("[docs-nav] failed to fetch Pro catalog:", error);
-  }
+  const comingSoonItems: SidebarNavItem[] = COMING_SOON_CATALOG.map(
+    (template) => ({
+      title: template.name,
+      href: "#",
+      items: [],
+      disabled: true,
+      label: "Soon",
+    }),
+  );
 
-  if (proItems.length === 0) return docsConfig.sidebarNav;
+  const placeholder: SidebarNavItem = {
+    title: "10+ more coming soon",
+    href: "#",
+    items: [],
+    disabled: true,
+  };
+
+  const extraItems = [...activeItems, ...comingSoonItems, placeholder];
+  if (extraItems.length === 0) return docsConfig.sidebarNav;
 
   return docsConfig.sidebarNav.map((section) => {
     if (section.title !== TEMPLATES_SECTION_TITLE) return section;
     return {
       ...section,
-      items: [...(section.items ?? []), ...proItems],
+      items: [...(section.items ?? []), ...extraItems],
     };
   });
 }

--- a/lib/pro-api.ts
+++ b/lib/pro-api.ts
@@ -112,31 +112,8 @@ export const proTemplatesApi = {
   },
 };
 
-/**
- * Build a deep link to the template detail page on pro.ruixen.com with
- * UTM/ref attribution so PostHog can follow the OSS → Pro funnel.
- */
-export function buildProTemplateUrl(
-  slug: string,
-  surface:
-    | "oss_templates"
-    | "oss_templates_get_pro"
-    | "oss_templates_preview"
-    | "oss_templates_footer"
-    | "oss_docs_sidebar" = "oss_templates",
-): string {
-  const base = `${PRO_SITE_URL}/templates/${encodeURIComponent(slug)}`;
-  try {
-    const url = new URL(base);
-    url.searchParams.set("ref", surface);
-    url.searchParams.set("utm_source", "ruixen");
-    url.searchParams.set("utm_medium", "template_card");
-    url.searchParams.set("utm_campaign", "bridge");
-    url.searchParams.set("slug", slug);
-    return url.toString();
-  } catch {
-    return base;
-  }
+export function buildProTemplateUrl(slug: string): string {
+  return `${PRO_SITE_URL}/templates/${encodeURIComponent(slug)}`;
 }
 
 export function formatUsdFromCents(cents: number): string {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,6 +8,8 @@ export interface NavItem {
   icon?: keyof typeof Icons;
   label?: string;
   paid?: boolean;
+  free?: boolean;
+  gold?: boolean;
   event?: string;
 }
 


### PR DESCRIPTION
## Summary

- Replace the runtime fetch to `pro.ruixen.com/api/v1/products` with a static catalog in `data/pro-catalog.ts` (Nguyen + Intellune, mirrored from the live Pro catalog). The templates listing and `/docs/templates/<slug>` pages no longer fail or show the *"We couldn't load the Pro catalog"* banner.
- Drop UTM/ref query strings from `buildProTemplateUrl` — template links now emit clean `/templates/<slug>` URLs.
- Inject Folio (coming soon, disabled) and a "10+ more coming soon" placeholder into the docs sidebar Templates section, mirroring pro.ruixen.com's own sidebar.
- New sidebar pill tones: Portfolio → blue "Free" (new `free` flag), MCP → lime "Free" (new `gold` flag), Pro templates (Nguyen/Intellune) → lime "Pro".

## Test plan

- [ ] `/templates` renders Portfolio, Intellune (rich card with dual video), Nguyen (rich card with dual video), Folio coming-soon card — no error banner.
- [ ] `/docs/templates/nguyen-one` and `/docs/templates/intellune` render full detail pages (features, highlights, sections, deps).
- [ ] `/docs/templates/portfolio` still renders from MDX.
- [ ] Docs sidebar Templates section shows Portfolio [Free blue], Intellune [Pro lime], Nguyen [Pro lime], Folio [Soon default], "10+ more coming soon" disabled.
- [ ] MCP sidebar entry shows lime "Free" pill.
- [ ] Template "Live Preview" / "Get Access" links go to `pro.ruixen.com/templates/<slug>` with no `?ref=` or `?utm_*`.
- [ ] `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm build` pass.