### PR TITLE
fix(sidebar): drop hardcoded Pro template entries that duplicated the…

### DIFF
--- a/config/docs.ts
+++ b/config/docs.ts
@@ -153,18 +153,9 @@ export const docsConfig: DocsConfig = {
           free: true,
           event: "template_portfolio_clicked",
         },
-        {
-          title: "Nguyen – AI Workspace",
-          href: `/docs/templates/nguyen-one`,
-          items: [],
-          label: "Pro",
-        },
-        {
-          title: "Intellune – AI Agent",
-          href: `/docs/templates/intellune`,
-          items: [],
-          label: "Pro",
-        },
+        // Pro templates are appended dynamically by getDocsSidebarNav() from
+        // data/pro-catalog.ts — do not re-list them here or the sidebar will
+        // render each one twice (hardcoded + dynamic).
       ],
     },
     {


### PR DESCRIPTION
dynamic catalog

Nguyen and Intellune were rendered twice in the Templates sidebar — once from the hardcoded entries in config/docs.ts (blue Pro label) and once from getDocsSidebarNav() appending data/pro-catalog.ts (green Pro badge). Removed the hardcoded duplicates and left a comment explaining why; Portfolio stays since it's a free in-repo template, not part of the Pro catalog.