### PR TITLE
feat(templates): add Folio + Vertex, fix media render and card spacing

### DIFF
--- a/app/templates/page.tsx
+++ b/app/templates/page.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/components/ui/card";
 import { TemplateProClickTracker } from "@/components/template-pro-click-tracker";
 import { ThemedTemplateMedia } from "@/components/themed-template-media";
+import { cn } from "@/lib/utils";
 
 // Pro catalog is hardcoded in data/pro-catalog.ts — no runtime fetch.
 
@@ -33,8 +34,8 @@ interface StaticTemplate {
   id: string;
   title: string;
   description: string;
-  image?: string;
-  video?: string;
+  videoLight?: string;
+  videoDark?: string;
   previewUrl: string;
   githubUrl?: string;
   price: "free";
@@ -52,8 +53,10 @@ const staticTemplates: StaticTemplate[] = [
     title: "Creative Portfolio Template",
     description:
       "A sleek portfolio template to highlight your creative journey and accomplishments.",
-    image: "/portfolio-preview.jpg",
-    video: "/portfolio.mp4",
+    videoLight:
+      "https://pub-940ccf6255b54fa799a9b01050e6c227.r2.dev/pro_ruixen_products/portfolio/portfolio-light-video.mp4",
+    videoDark:
+      "https://pub-940ccf6255b54fa799a9b01050e6c227.r2.dev/pro_ruixen_products/portfolio/portfolio-dark-video.mp4",
     previewUrl: "https://portfolio-ruixens-projects.vercel.app/",
     githubUrl: "https://github.com/ruixenui/portfolio",
     price: "free",
@@ -178,35 +181,52 @@ function StaticTemplateCard({ template }: { template: StaticTemplate }) {
           </div>
         </div>
 
-        <div className="relative hover:shadow-[0_8px_32px_rgba(0,0,0,0.1)] hover:backdrop-blur-sm transition-all duration-300 rounded-3xl cursor-pointer">
-          {template.video ? (
-            <video
-              autoPlay
-              loop
-              muted
-              className="w-full h-[26rem] rounded-3xl hover:scale-[1.06] transition-all duration-300 object-cover"
-              src={template.video}
-            />
-          ) : template.image ? (
-            <Image
-              src={template.image}
-              alt={template.title}
-              width={800}
-              height={600}
-              className="w-full h-full rounded-lg object-cover"
-            />
-          ) : (
-            <div
-              aria-hidden
-              className="w-full h-[26rem] rounded-3xl bg-gradient-to-br from-muted to-muted/40 flex items-center justify-center text-muted-foreground text-sm"
-            >
-              {template.title}
+        <div className="px-6 pb-6 md:px-0 md:pr-6 md:py-6">
+          <div className="relative overflow-hidden rounded-3xl hover:shadow-[0_8px_32px_rgba(0,0,0,0.1)] hover:backdrop-blur-sm transition-all duration-300 cursor-pointer">
+            {template.videoLight || template.videoDark ? (
+              <>
+                {template.videoLight && (
+                  <video
+                    autoPlay
+                    loop
+                    muted
+                    playsInline
+                    preload="metadata"
+                    src={template.videoLight}
+                    className={cn(
+                      "w-full h-[26rem] rounded-3xl hover:scale-[1.06] transition-all duration-300 object-cover",
+                      template.videoDark && "block dark:hidden",
+                    )}
+                  />
+                )}
+                {template.videoDark && (
+                  <video
+                    autoPlay
+                    loop
+                    muted
+                    playsInline
+                    preload="metadata"
+                    src={template.videoDark}
+                    className={cn(
+                      "w-full h-[26rem] rounded-3xl hover:scale-[1.06] transition-all duration-300 object-cover",
+                      template.videoLight && "hidden dark:block",
+                    )}
+                  />
+                )}
+              </>
+            ) : (
+              <div
+                aria-hidden
+                className="w-full h-[26rem] rounded-3xl bg-gradient-to-br from-muted to-muted/40 flex items-center justify-center text-muted-foreground text-sm"
+              >
+                {template.title}
+              </div>
+            )}
+            <div className="absolute top-4 right-4 z-10">
+              <Badge variant="secondary" className="bg-[#bef853]">
+                Free
+              </Badge>
             </div>
-          )}
-          <div className="absolute top-4 right-4">
-            <Badge variant="secondary" className="bg-[#bef853]">
-              Free
-            </Badge>
           </div>
         </div>
       </div>
@@ -322,28 +342,30 @@ function ProTemplateCard({ template }: { template: ProTemplate }) {
           </div>
         </div>
 
-        <Link
-          href={detailHref}
-          target="_blank"
-          rel="noopener noreferrer"
-          data-pro-template-preview={template.slug}
-          className="relative block hover:shadow-[0_8px_32px_rgba(0,0,0,0.1)] hover:backdrop-blur-sm transition-all duration-300 rounded-3xl cursor-pointer"
-        >
-          <ThemedTemplateMedia
-            template={template}
-            className="w-full h-[26rem] rounded-3xl hover:scale-[1.06] transition-all duration-300 object-cover object-top"
-            width={1200}
-            height={800}
-          />
-          <div className="absolute top-4 right-4">
-            <Badge
-              variant={template.is_free ? "secondary" : "default"}
-              className="bg-[#bef853]"
-            >
-              {template.is_free ? "Free" : "Pro"}
-            </Badge>
-          </div>
-        </Link>
+        <div className="px-6 pb-6 md:px-0 md:pr-6 md:py-6">
+          <Link
+            href={detailHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            data-pro-template-preview={template.slug}
+            className="relative block overflow-hidden rounded-3xl hover:shadow-[0_8px_32px_rgba(0,0,0,0.1)] hover:backdrop-blur-sm transition-all duration-300 cursor-pointer"
+          >
+            <ThemedTemplateMedia
+              template={template}
+              className="w-full h-[26rem] rounded-3xl hover:scale-[1.06] transition-all duration-300 object-cover object-top"
+              width={1200}
+              height={800}
+            />
+            <div className="absolute top-4 right-4 z-10">
+              <Badge
+                variant={template.is_free ? "secondary" : "default"}
+                className="bg-[#bef853]"
+              >
+                {template.is_free ? "Free" : "Pro"}
+              </Badge>
+            </div>
+          </Link>
+        </div>
       </div>
     </Card>
   );
@@ -380,18 +402,20 @@ function ComingSoonTemplateCard({
             Available Soon
           </div>
         </div>
-        <div className="relative rounded-3xl overflow-hidden">
-          <Image
-            src={imageUrl}
-            alt={name}
-            width={1200}
-            height={800}
-            className="w-full h-[26rem] rounded-3xl object-cover object-top grayscale-[30%]"
-            unoptimized
-          />
-          <div className="absolute inset-0 flex items-center justify-center bg-background/40 backdrop-blur-[2px] rounded-3xl">
-            <div className="rounded-full bg-background/80 px-4 py-2 text-sm font-medium text-muted-foreground shadow-sm">
-              Coming Very Soon
+        <div className="px-6 pb-6 md:px-0 md:pr-6 md:py-6">
+          <div className="relative rounded-3xl overflow-hidden">
+            <Image
+              src={imageUrl}
+              alt={name}
+              width={1200}
+              height={800}
+              className="w-full h-[26rem] rounded-3xl object-cover object-top grayscale-[30%]"
+              unoptimized
+            />
+            <div className="absolute inset-0 flex items-center justify-center bg-background/40 backdrop-blur-[2px] rounded-3xl">
+              <div className="rounded-full bg-background/80 px-4 py-2 text-sm font-medium text-muted-foreground shadow-sm">
+                Coming Very Soon
+              </div>
             </div>
           </div>
         </div>

--- a/components/themed-template-media.tsx
+++ b/components/themed-template-media.tsx
@@ -2,9 +2,9 @@
 
 import * as React from "react";
 import Image from "next/image";
-import { useTheme } from "next-themes";
 
 import type { ProTemplate } from "@/types/pro-templates";
+import { cn } from "@/lib/utils";
 
 interface ThemedTemplateMediaProps {
   template: ProTemplate;
@@ -26,57 +26,86 @@ function pickImages(template: ProTemplate) {
   return { light, dark };
 }
 
+// Renders both light + dark variants and toggles them via Tailwind `dark:` so
+// the correct one is visible on first paint — no SSR/hydration flash, no
+// remount when the theme flips (which would otherwise restart the video).
 export function ThemedTemplateMedia({
   template,
   className,
   width = 1200,
   height = 800,
 }: ThemedTemplateMediaProps) {
-  const { resolvedTheme } = useTheme();
-  const [mounted, setMounted] = React.useState(false);
-  React.useEffect(() => setMounted(true), []);
-
-  // Render light variant on server / before hydration to avoid mismatch;
-  // swap to dark once theme resolves on the client.
-  const isDark = mounted && resolvedTheme === "dark";
-
   const { light: lightImg, dark: darkImg } = pickImages(template);
-  const poster = isDark ? darkImg?.image_url : lightImg?.image_url;
-  const videoUrl = isDark
-    ? template.video_url_dark || template.video_url_light
-    : template.video_url_light || template.video_url_dark;
-  const imgSrc = isDark ? darkImg : lightImg;
+  const lightVideo =
+    template.video_url_light ?? template.video_url_dark ?? null;
+  const darkVideo =
+    template.video_url_dark ?? template.video_url_light ?? null;
 
-  if (videoUrl) {
+  if (lightVideo || darkVideo) {
     return (
-      <video
-        key={videoUrl}
-        autoPlay
-        loop
-        muted
-        playsInline
-        src={videoUrl}
-        poster={poster ?? undefined}
-        className={className}
-      />
+      <>
+        {lightVideo && (
+          <video
+            autoPlay
+            loop
+            muted
+            playsInline
+            preload="metadata"
+            src={lightVideo}
+            poster={lightImg?.image_url}
+            className={cn(className, "block dark:hidden")}
+          />
+        )}
+        {darkVideo && (
+          <video
+            autoPlay
+            loop
+            muted
+            playsInline
+            preload="metadata"
+            src={darkVideo}
+            poster={darkImg?.image_url}
+            className={cn(className, "hidden dark:block")}
+          />
+        )}
+      </>
     );
   }
-  if (imgSrc) {
+
+  if (lightImg || darkImg) {
     return (
-      <Image
-        src={imgSrc.image_url}
-        alt={imgSrc.alt_text ?? template.name}
-        width={width}
-        height={height}
-        className={className}
-        unoptimized
-      />
+      <>
+        {lightImg && (
+          <Image
+            src={lightImg.image_url}
+            alt={lightImg.alt_text ?? template.name}
+            width={width}
+            height={height}
+            className={cn(className, "block dark:hidden")}
+            unoptimized
+          />
+        )}
+        {darkImg && darkImg !== lightImg && (
+          <Image
+            src={darkImg.image_url}
+            alt={darkImg.alt_text ?? template.name}
+            width={width}
+            height={height}
+            className={cn(className, "hidden dark:block")}
+            unoptimized
+          />
+        )}
+      </>
     );
   }
+
   return (
     <div
       aria-hidden
-      className={`${className ?? ""} flex items-center justify-center bg-gradient-to-br from-muted to-muted/40 text-muted-foreground text-sm`}
+      className={cn(
+        className,
+        "flex items-center justify-center bg-gradient-to-br from-muted to-muted/40 text-muted-foreground text-sm",
+      )}
     >
       {template.name}
     </div>

--- a/content/docs/templates/portfolio.mdx
+++ b/content/docs/templates/portfolio.mdx
@@ -11,8 +11,19 @@ published: true
     autoPlay
     loop
     muted
-    src="/portfolio.mp4"
-    className="w-full rounded-xl border"
+    playsInline
+    preload="metadata"
+    src="https://pub-940ccf6255b54fa799a9b01050e6c227.r2.dev/pro_ruixen_products/portfolio/portfolio-light-video.mp4"
+    className="w-full rounded-xl border block dark:hidden"
+  />
+  <video
+    autoPlay
+    loop
+    muted
+    playsInline
+    preload="metadata"
+    src="https://pub-940ccf6255b54fa799a9b01050e6c227.r2.dev/pro_ruixen_products/portfolio/portfolio-dark-video.mp4"
+    className="w-full rounded-xl border hidden dark:block"
   />
   <div className="flex w-full flex-col gap-2 sm:flex-row">
     <TemplateOpen url="https://github.com/ruixenui/portfolio" free />

--- a/data/pro-catalog.ts
+++ b/data/pro-catalog.ts
@@ -1,10 +1,11 @@
 /**
  * Pro template catalog — hardcoded mirror of the real pro.ruixen.com catalog.
  *
- * Source of truth (both active templates live on pro.ruixen.com):
+ * Source of truth (active templates live on pro.ruixen.com):
  *   - Nguyen   → pro.ruixen.com/backend/scripts/add_nguyen.py
  *   - Intellune → pulled from the live Pro product detail JSON
  *                 (pro.ruixen.com/templates/intellune RSC payload)
+ *   - Folio / Vertex → pro.ruixen.com/backend/scripts/seed_templates.py
  *   - Coming-soon teaser → pro.ruixen.com/frontend/apps/www/app/templates/page.tsx
  *
  * The OSS site used to fetch /api/v1/products from pro.ruixen.com at build time.
@@ -267,16 +268,248 @@ export const PRO_CATALOG: ProTemplate[] = [
       },
     ],
   }),
+  baseTemplate({
+    id: 3,
+    name: "Folio — Open Source Data Intelligence Landing Template",
+    slug: "folio",
+    short_description:
+      "Production-grade Next.js 15 landing template for open-source data intelligence and AI charting products. Hero with dashboard preview, Bento, How-it-Works, FAQ.",
+    long_description:
+      "Folio is a polished, production-ready marketing site for open-source data intelligence, BI, and AI-charting products. Built on Next.js 15 App Router, React 19, Tailwind CSS 4, and shadcn/ui, it ships with a Hero featuring an in-page dashboard preview, a Bento feature grid, animated Feature Tabs, a How-it-Works walkthrough, Testimonials, Customers / logo cloud, Pricing, FAQ, and CTA. Pre-built Pricing, Contact, Privacy, Terms, and a custom 404 page. Light/dark mode via next-themes, type-safe env via @t3-oss/env-nextjs, optional Drizzle + Neon Postgres and Resend + React Email scaffolding, Biome for one-command lint and format. Ideal positioning for OSS-first BI tools and natural-language-to-SQL products.",
+    product_type: "template",
+    category: null,
+    tech_stack: ["nextjs", "react", "tailwind"],
+    features: [
+      "Next.js 15 App Router + Turbopack",
+      "React 19 + TypeScript 5.7",
+      "Tailwind CSS 4 + shadcn/ui + Radix primitives",
+      "Light / Dark mode (next-themes)",
+      "Framer Motion animations",
+      "Hero with in-page dashboard preview",
+      "Bento feature grid + animated Feature Tabs",
+      "How-it-Works walkthrough",
+      "Testimonials, Customers, Pricing, FAQ, CTA",
+      "Pricing, Contact, Privacy, Terms, 404 pages",
+      "SEO: dynamic metadata, sitemap, Open Graph",
+      "Type-safe env with @t3-oss/env-nextjs",
+      "Optional Drizzle ORM + Neon Postgres",
+      "Optional Resend + React Email",
+      "React Hook Form + Zod forms",
+      "Biome lint + format",
+    ],
+    highlights: [
+      "Save 80+ hours of frontend work",
+      "Positioning baked in for OSS / data-intelligence products",
+      "Hero with embedded dashboard preview",
+      "Light + dark mode, fully responsive",
+      "Ship to Vercel in minutes",
+      "Yours to own — unlimited projects, commercial use",
+    ],
+    sections_included: [
+      "Header with mobile menu + theme toggle",
+      "Hero with dashboard preview",
+      "Logo Cloud / Customers carousel",
+      "Bento feature grid",
+      "Feature Tabs (animated)",
+      "How-it-Works walkthrough",
+      "Services",
+      "Product Tabs",
+      "Testimonials",
+      "Quote",
+      "Pricing comparison table",
+      "FAQ accordion",
+      "CTA",
+      "Footer",
+    ],
+    dependencies: {
+      next: "15.5.9",
+      react: "19.0.0",
+      typescript: "5.7.3",
+      tailwindcss: "4.0.4",
+      "framer-motion": "12.23.26",
+      "drizzle-orm": "0.41.0",
+      "better-auth": "1.2.5",
+      resend: "4.2.0",
+    },
+    price_usd_cents: 3900,
+    is_free: false,
+    is_included_in_membership: true,
+    demo_url: "https://folio-topaz-delta.vercel.app",
+    preview_url: "https://folio-topaz-delta.vercel.app",
+    video_url_light: `${R2_BASE}/folio/folio-light-theme.mp4`,
+    video_url_dark: `${R2_BASE}/folio/folio-dark-theme.mp4`,
+    what_is_this:
+      "Folio is a Next.js 15 marketing template built for open-source data intelligence, business-intelligence, and AI-charting products. It bundles a Hero with an embedded dashboard preview, a Bento grid, animated Feature Tabs, and the supporting pages every OSS landing page needs — so you can launch a credible site without rebuilding the same scaffolding.",
+    who_is_this_for:
+      "Founders and maintainers launching an open-source data tool, natural-language-to-SQL product, AI-charting library, or BI platform who need a polished marketing site that signals credibility from the first scroll — without spending weeks on design polish, dark-mode QA, and section assembly.",
+    is_active: true,
+    is_featured: true,
+    coming_soon: false,
+    version: "1.0.0",
+    images: [
+      {
+        id: 1,
+        image_url: `${R2_BASE}/folio/folio-image-01.png`,
+        alt_text: "Folio landing — hero with dashboard preview",
+        display_order: 0,
+        is_thumbnail: true,
+      },
+      {
+        id: 2,
+        image_url: `${R2_BASE}/folio/folio-image-02.png`,
+        alt_text: "Folio landing — bento grid",
+        display_order: 1,
+        is_thumbnail: false,
+      },
+      {
+        id: 3,
+        image_url: `${R2_BASE}/folio/folio-image-03.png`,
+        alt_text: "Folio landing — feature tabs",
+        display_order: 2,
+        is_thumbnail: false,
+      },
+      {
+        id: 4,
+        image_url: `${R2_BASE}/folio/folio-image-04.png`,
+        alt_text: "Folio landing — how it works",
+        display_order: 3,
+        is_thumbnail: false,
+      },
+      {
+        id: 5,
+        image_url: `${R2_BASE}/folio/folio-image-05.png`,
+        alt_text: "Folio landing — testimonials / customers",
+        display_order: 4,
+        is_thumbnail: false,
+      },
+      {
+        id: 6,
+        image_url: `${R2_BASE}/folio/folio-image-06.png`,
+        alt_text: "Folio landing — pricing / CTA",
+        display_order: 5,
+        is_thumbnail: false,
+      },
+    ],
+  }),
+  baseTemplate({
+    id: 4,
+    name: "Vertex — AI Workflow Automation Landing Template",
+    slug: "vertex",
+    short_description:
+      "Production-grade Next.js 15 landing page for AI workflow automation products. 10+ sections, light/dark, SEO-ready.",
+    long_description:
+      "Vertex is a polished, production-ready marketing site for AI workflow automation startups, built on Next.js 15 App Router, React 19, Tailwind CSS 4, and shadcn/ui. It ships with a full landing page composed of 10+ section components (Hero with rotating CRM cards, Features, Services, Product Tabs, Customers, Testimonials, Quote, Pricing comparison, FAQ, CTA), plus pre-built Pricing, Contact, Privacy, Terms, and custom 404 pages. Light/dark mode via next-themes, type-safe env via @t3-oss/env-nextjs, optional Drizzle + Neon Postgres and Resend + React Email scaffolding, and Biome for one-command lint and format.",
+    product_type: "template",
+    category: null,
+    tech_stack: ["nextjs", "react", "tailwind"],
+    features: [
+      "Next.js 15 App Router + Turbopack",
+      "React 19 + TypeScript 5.7",
+      "Tailwind CSS 4 + shadcn/ui + Radix primitives",
+      "Light / Dark mode (next-themes)",
+      "Framer Motion animations",
+      "10+ pre-built landing sections",
+      "Pricing, Contact, Privacy, Terms, 404 pages",
+      "SEO: dynamic metadata, sitemap, Open Graph",
+      "Type-safe env with @t3-oss/env-nextjs",
+      "Optional Drizzle ORM + Neon Postgres",
+      "Optional Resend + React Email",
+      "React Hook Form + Zod forms",
+      "Biome lint + format",
+    ],
+    highlights: [
+      "Save 80+ hours of frontend work",
+      "AI-product positioning baked into copy and layout",
+      "Light + dark mode, fully responsive",
+      "Ship to Vercel in minutes",
+      "Yours to own — unlimited projects, commercial use",
+    ],
+    sections_included: [
+      "Header with mobile menu + theme toggle",
+      "Hero with rotating CRM cards",
+      "Logo Cloud",
+      "Features grid",
+      "Services",
+      "Product Tabs",
+      "Customers",
+      "Testimonials carousel",
+      "Quote",
+      "Pricing comparison table",
+      "FAQ accordion",
+      "CTA",
+      "Footer",
+    ],
+    dependencies: {
+      next: "15.5.9",
+      react: "19.0.0",
+      typescript: "5.7.3",
+      tailwindcss: "4.0.4",
+      "framer-motion": "12.23.26",
+      "drizzle-orm": "0.41.0",
+      "better-auth": "1.2.5",
+      resend: "4.2.0",
+    },
+    price_usd_cents: 3900,
+    is_free: false,
+    is_included_in_membership: true,
+    demo_url: "https://vertex-one-lovat.vercel.app",
+    preview_url: "https://vertex-one-lovat.vercel.app",
+    video_url_light: `${R2_BASE}/vertex/vertex-light-video.mp4`,
+    video_url_dark: `${R2_BASE}/vertex/vertex-dark-video.mp4`,
+    what_is_this:
+      "Vertex is a Next.js 15 marketing template purpose-built for AI workflow automation products. It bundles a complete landing page, supporting pages, and modern tooling so you can launch a credible site without spending weeks on layout, polish, and dark-mode QA.",
+    who_is_this_for:
+      "Founders and indie hackers launching an AI workflow, agents, or automation product who want a polished, conversion-tuned site running in a day — not a sprint of design, copy structure, and section assembly.",
+    is_active: true,
+    is_featured: true,
+    coming_soon: false,
+    version: "1.0.0",
+    images: [
+      {
+        id: 1,
+        image_url: `${R2_BASE}/vertex/vertex-image-01.png`,
+        alt_text: "Vertex landing — hero",
+        display_order: 0,
+        is_thumbnail: true,
+      },
+      {
+        id: 2,
+        image_url: `${R2_BASE}/vertex/vertex-image-02.png`,
+        alt_text: "Vertex landing — features",
+        display_order: 1,
+        is_thumbnail: false,
+      },
+      {
+        id: 3,
+        image_url: `${R2_BASE}/vertex/vertex-image-03.png`,
+        alt_text: "Vertex landing — services / product tabs",
+        display_order: 2,
+        is_thumbnail: false,
+      },
+      {
+        id: 4,
+        image_url: `${R2_BASE}/vertex/vertex-image-04.png`,
+        alt_text: "Vertex landing — pricing",
+        display_order: 3,
+        is_thumbnail: false,
+      },
+      {
+        id: 5,
+        image_url: `${R2_BASE}/vertex/vertex-image-05.png`,
+        alt_text: "Vertex landing — testimonials / CTA",
+        display_order: 4,
+        is_thumbnail: false,
+      },
+    ],
+  }),
 ];
 
-export const COMING_SOON_CATALOG = [
-  {
-    name: "Folio – Win More Clients",
-    description:
-      "Turn visitors into clients. A showcase that makes your work impossible to ignore.",
-    image_url: `${R2_BASE}/dummy-02.png`,
-  },
-] as const;
+// Folio and Vertex shipped as real products — no coming-soon teasers right now.
+export const COMING_SOON_CATALOG: ReadonlyArray<{
+  name: string;
+  description: string;
+  image_url: string;
+}> = [];
 
 export function getProTemplates(): ProTemplate[] {
   return PRO_CATALOG.filter((t) => t.is_active && !t.coming_soon);


### PR DESCRIPTION
## Summary

Three commits — adds two new Pro templates, fixes a long-standing dark-mode flash on every template card, and converts the free Portfolio template to the same light/dark video pattern as the new ones.

### 1. `feat(templates): add Folio and Vertex to Pro catalog`

`data/pro-catalog.ts` is the static mirror of `pro.ruixen.com`'s catalog (the live `/api/v1/products` fetch was retired earlier because it was unreliable). Adding the two new products that shipped on pro.ruixen.com:

- **Folio** (`/docs/templates/folio`, $39, featured) — Open Source Data Intelligence landing template. Demo: [folio-topaz-delta.vercel.app](https://folio-topaz-delta.vercel.app).
- **Vertex** (`/docs/templates/vertex`, $39, featured) — AI Workflow Automation landing template. Demo: [vertex-one-lovat.vercel.app](https://vertex-one-lovat.vercel.app).

Source fields pulled verbatim from `pro.ruixen.com/backend/scripts/seed_templates.py`. Both ship with light + dark R2 videos and 5–6 R2 images each.

Also drops the obsolete *"Folio – Win More Clients"* `COMING_SOON_CATALOG` teaser — Folio is now a real product. Kept the export as an empty `ReadonlyArray` so `lib/docs-nav.ts` and `app/templates/page.tsx` still type-check and iterate as no-ops.

### 2. `fix(themed-template-media): eliminate dark-mode hydration flicker`

`ThemedTemplateMedia` was gating dark/light selection on a `mounted` flag (`useState(false)` + `useEffect setMounted(true)`). SSR and the first client paint **always** rendered the light variant; only after hydration would it remount the `<video>` with the dark `src` (via `key={videoUrl}`), causing:

- a visible flash of the light theme on dark pages, and
- a full video restart whenever the theme flipped.

Now renders both light and dark variants and toggles them with Tailwind `block dark:hidden` / `hidden dark:block`. Same pattern already in use across `preview-carousel.tsx`, `mdx-components.tsx`, `main-nav.tsx`, `icons.tsx`. Also added `preload="metadata"` so the first frame paints quickly while the rest of the video streams.

### 3. `fix(templates): add card right-side padding and swap portfolio to light/dark videos`

**Spacing** — right-column media was butted up against the card edge while the left column had `p-6`, producing an asymmetric "no space on the right" layout across all three card types (Static, Pro, ComingSoon). Wrapped each right-column media in `px-6 pb-6 md:px-0 md:pr-6 md:py-6` so it's inset symmetrically with the left column. Bumped the Free/Pro badge to `z-10` and added `overflow-hidden` to the Pro `<Link>` so `hover:scale-[1.06]` no longer overflows past the rounded corners now that the wrapper is no longer the clipping element.

**Portfolio dual-video** — the free Portfolio template still pointed at a single local `/portfolio.mp4`. Swapped it for `videoLight` + `videoDark` R2 URLs (`portfolio-light-video.mp4` 1.8 MB / `portfolio-dark-video.mp4` 1.5 MB), rendering both with the same CSS theme toggle as `ThemedTemplateMedia`. Dropped the now-unused `image` / `video` fields from the `StaticTemplate` type. Mirrored the same dual-video pair into `content/docs/templates/portfolio.mdx` so the docs page also renders the matching theme variant.

> `public/portfolio.mp4` and `public/portfolio-preview.jpg` are now orphaned but were not deleted in this PR.

## Test plan

- [x] `tsc --noEmit -p tsconfig.json` — clean for all 4 touched files. Pre-existing errors in untracked `registry/ruixenui/floating-cards-hero.tsx` are unrelated (separate component PR).
- [x] R2 asset reachability — `curl -sI` returns `200 OK` for all 6 newly-referenced videos and all 6 portfolio assets.
- [ ] Visit `/templates` in dark mode — confirm:
  - [ ] Folio and Vertex appear as Premium Templates with their dark-theme videos autoplaying (no light-theme flash).
  - [ ] Intellune and Nguyen also no longer flash light on first paint.
  - [ ] Every card has visible right-side padding (no edge bleed).
  - [ ] Portfolio (Free) plays its dark video; toggling theme swaps cleanly without remounting/restarting the video.
- [ ] Visit `/templates` in light mode — confirm the light variant plays for every template.
- [ ] Visit `/docs/templates/folio` and `/docs/templates/vertex` — confirm the Pro detail pages render with themed hero video, what-is/who-is sections, highlights, features, sections-included, tech stack, and dependencies tables.
- [ ] Visit `/docs/templates/portfolio` — confirm the embedded video swaps light/dark with the theme.
- [ ] Confirm sidebar (`/docs/templates/*`) lists Folio and Vertex under Templates (titles shortened to `Folio` / `Vertex` by `shortenTemplateTitle`).