### PR TITLE
feat(seo): optimize generator pages + funnel tool traffic to product

### DIFF
--- a/app/(generator)/generator/css-generator/layout.tsx
+++ b/app/(generator)/generator/css-generator/layout.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "CSS Gradient Generator — Copy CSS & Tailwind",
+  description:
+    "Build linear, radial and conic CSS gradients with a live editor. Drag color stops, pick presets, then copy ready-to-use CSS & Tailwind. Free, no signup.",
+  keywords: [
+    "css gradient generator",
+    "gradient generator",
+    "linear gradient css",
+    "radial gradient css",
+    "conic gradient",
+    "tailwind gradient generator",
+    "ui gradients",
+    "ruixen ui tools",
+  ],
+  openGraph: {
+    title: "CSS Gradient Generator — Linear, Radial & Conic | Ruixen UI",
+    description:
+      "Visual CSS gradient editor with color stops, presets and one-click export to CSS & Tailwind.",
+    url: "/generator/css-generator",
+    type: "website",
+  },
+  alternates: { canonical: "/generator/css-generator" },
+};
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/app/(generator)/generator/css-generator/page.tsx
+++ b/app/(generator)/generator/css-generator/page.tsx
@@ -9,6 +9,8 @@ import { PresetsGrid } from "@/components/generator/css/presets-grid";
 import { ExportButtons } from "@/components/generator/css/export-buttons";
 import FAQSection from "@/components/sections/faq-section";
 import { FAQItem } from "@/registry/ruixenui/staggered-faq-section";
+import { GeneratorCta } from "@/components/generator/generator-cta";
+import { RelatedTools } from "@/components/generator/related-tools";
 
 const faqItems: FAQItem[] = [
   {
@@ -143,6 +145,9 @@ export default function GradientGeneratorPage() {
           <SeoArticle />
         </section>
       </div>
+
+      <GeneratorCta tool="css-generator" />
+      <RelatedTools current="css-generator" />
     </main>
   );
 }

--- a/app/(generator)/generator/glass-morphism/page.tsx
+++ b/app/(generator)/generator/glass-morphism/page.tsx
@@ -1,12 +1,13 @@
 // app/glass/page.tsx
 import GlassGeneratorPage from "@/components/generator/glass/glass-generator-page";
+import { GeneratorCta } from "@/components/generator/generator-cta";
+import { RelatedTools } from "@/components/generator/related-tools";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title:
-    "Glassmorphism Generator – Free CSS & Tailwind Tool (2025) | Ruixen UI",
+  title: "Glassmorphism Generator — Free CSS & Tailwind",
   description:
-    "Generate beautiful glassmorphism UI instantly. Customize blur, transparency, borders, shadows and gradients. Export CSS & Tailwind. 100% free, modern, fast and easy.",
+    "Generate glassmorphism UI instantly — tune blur, transparency, borders and gradients with a live preview. Copy production-ready CSS & Tailwind. Free, no signup.",
   keywords: [
     "glassmorphism generator",
     "css glass generator",
@@ -22,12 +23,18 @@ export const metadata: Metadata = {
     title: "Glassmorphism Generator – Free CSS & Tailwind Tool | Ruixen UI",
     description:
       "Create beautiful frosted glass UI with real-time preview. Blur, transparency, borders, gradients and export-ready CSS & Tailwind.",
-    url: "https://www.ruixen.com/tools/glass",
+    url: "/generator/glass-morphism",
     type: "website",
   },
-  alternates: { canonical: "https://www.ruixen.com/tools/glass" },
+  alternates: { canonical: "/generator/glass-morphism" },
 };
 
 export default function Page() {
-  return <GlassGeneratorPage />;
+  return (
+    <>
+      <GlassGeneratorPage />
+      <GeneratorCta tool="glass-morphism" />
+      <RelatedTools current="glass-morphism" />
+    </>
+  );
 }

--- a/app/(generator)/generator/shadow-generator/page.tsx
+++ b/app/(generator)/generator/shadow-generator/page.tsx
@@ -1,10 +1,12 @@
 import ShadowGeneratorPage from "@/components/generator/shadow/shadow-generator-page";
+import { GeneratorCta } from "@/components/generator/generator-cta";
+import { RelatedTools } from "@/components/generator/related-tools";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Shadow Generator — Beautiful Shadows in Seconds | Ruixen UI (2025)",
+  title: "Tailwind Shadow Generator — CSS Box-Shadow Tool",
   description:
-    "Generate beautiful modern UI shadows for cards, buttons, modals and components. Build layered, soft, hard, inset, neumorphism and elevation shadows. Export CSS and Tailwind instantly.",
+    "Create soft, layered and neumorphic box-shadows with a live preview. Build elevation and inset shadows, then copy CSS & Tailwind instantly. Free, no signup.",
   keywords: [
     "shadow generator",
     "css box-shadow generator",
@@ -20,12 +22,18 @@ export const metadata: Metadata = {
     title: "Shadow Generator — Create Beautiful Shadows in Seconds | Ruixen UI",
     description:
       "Professional real-time shadow builder with presets, layers, and instant export to CSS & Tailwind.",
-    url: "https://www.ruixen.com/tools/shadow",
+    url: "/generator/shadow-generator",
     type: "website",
   },
-  alternates: { canonical: "https://www.ruixen.com/tools/shadow" },
+  alternates: { canonical: "/generator/shadow-generator" },
 };
 
 export default function Page() {
-  return <ShadowGeneratorPage />;
+  return (
+    <>
+      <ShadowGeneratorPage />
+      <GeneratorCta tool="shadow-generator" />
+      <RelatedTools current="shadow-generator" />
+    </>
+  );
 }

--- a/app/(gradients)/gradients/layout.tsx
+++ b/app/(gradients)/gradients/layout.tsx
@@ -1,0 +1,29 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "UI Gradients — Free 4K Gradient Backgrounds",
+  description:
+    "Browse and download free 4K gradient backgrounds for UIs, hero sections and wallpapers. Copy CSS or export PNG in one click. Curated, modern gradient collection.",
+  keywords: [
+    "ui gradients",
+    "gradient backgrounds",
+    "4k gradients",
+    "hero gradient background",
+    "gradient wallpapers",
+    "css gradients",
+    "ruixen ui tools",
+  ],
+  openGraph: {
+    title: "UI Gradients — Free 4K Gradient Backgrounds | Ruixen UI",
+    description:
+      "Curated 4K gradient backgrounds for UI, heroes and wallpapers. Copy CSS or download PNG instantly.",
+    url: "/gradients",
+    type: "website",
+  },
+  alternates: { canonical: "/gradients" },
+};
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/app/(gradients)/gradients/page.tsx
+++ b/app/(gradients)/gradients/page.tsx
@@ -27,6 +27,8 @@ import {
   getGradientsByCategory,
   type Gradient,
 } from "@/lib/gradients-data";
+import { GeneratorCta } from "@/components/generator/generator-cta";
+import { RelatedTools } from "@/components/generator/related-tools";
 
 export default function GradientsPage() {
   const [selectedCategory, setSelectedCategory] = useState<string>("all");
@@ -340,6 +342,9 @@ export default function GradientsPage() {
           </div>
         )}
       </div>
+
+      <GeneratorCta tool="gradients" />
+      <RelatedTools current="gradients" />
     </div>
   );
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -45,6 +45,26 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       lastModified: new Date(),
       priority: 0.8,
     },
+    {
+      url: `${protocol}://${domain}/generator/glass-morphism`,
+      lastModified: new Date(),
+      priority: 0.8,
+    },
+    {
+      url: `${protocol}://${domain}/generator/css-generator`,
+      lastModified: new Date(),
+      priority: 0.8,
+    },
+    {
+      url: `${protocol}://${domain}/generator/shadow-generator`,
+      lastModified: new Date(),
+      priority: 0.8,
+    },
+    {
+      url: `${protocol}://${domain}/gradients`,
+      lastModified: new Date(),
+      priority: 0.8,
+    },
     ...allUseCasePaths().map(({ type, useCase }) => ({
       url: `${protocol}://${domain}/sections/${type}/${useCase}`,
       lastModified: new Date(),

--- a/components/generator/generator-cta.tsx
+++ b/components/generator/generator-cta.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowRight, Sparkles } from "lucide-react";
+
+import { trackEvent } from "@/lib/events";
+
+/**
+ * GeneratorCta — funnels free-tool visitors into the product.
+ *
+ * Generator pages are the site's biggest organic entry point but were a
+ * dead end (no path to the component library or Pro). This callout bridges
+ * tool-seekers to the OSS component library (primary, low friction) with a
+ * Pro upsell (secondary). Both clicks are tracked with a generator-specific
+ * `surface` so the tool→product funnel can be measured on its own.
+ */
+export function GeneratorCta({ tool }: { tool: string }) {
+  const surface = `generator_${tool}`;
+
+  return (
+    <section className="mx-auto w-full max-w-7xl px-4 md:px-6">
+      <div className="overflow-hidden rounded-2xl border border-blue-300/60 bg-blue-50/50 p-6 dark:border-blue-500/30 dark:bg-blue-950/20 sm:p-8">
+        <div className="flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
+          <div className="max-w-xl">
+            <div className="inline-flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-blue-600 dark:text-blue-400">
+              <Sparkles className="size-3.5" />
+              Ruixen UI
+            </div>
+            <h2 className="mt-2 text-xl font-bold tracking-tight text-foreground sm:text-2xl">
+              Skip the boilerplate — ship UI faster
+            </h2>
+            <p className="mt-1.5 text-sm text-muted-foreground">
+              You came for the tool. Stay for 240+ copy-paste components for
+              shadcn — hero sections, pricing tables, navbars and more. Free and
+              open source, with Pro templates when you need them.
+            </p>
+          </div>
+          <div className="flex shrink-0 flex-col gap-2 sm:flex-row">
+            <Link
+              href="/docs/components"
+              onClick={() =>
+                trackEvent({
+                  name: "cta_click",
+                  properties: { surface, target: "component_library" },
+                })
+              }
+              className="inline-flex items-center justify-center gap-1.5 rounded-lg bg-foreground px-4 py-2.5 text-sm font-semibold text-background transition-opacity hover:opacity-90"
+            >
+              Browse components
+              <ArrowRight className="size-4" />
+            </Link>
+            <Link
+              href={`https://pro.ruixen.com/pricing?ref=oss_${surface}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() =>
+                trackEvent({
+                  name: "oss_pro_cta_clicked",
+                  properties: { surface, slug: null },
+                })
+              }
+              className="inline-flex items-center justify-center gap-1.5 rounded-lg border border-border bg-background px-4 py-2.5 text-sm font-semibold text-foreground transition-colors hover:bg-accent"
+            >
+              See Ruixen Pro
+            </Link>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/generator/related-tools.tsx
+++ b/components/generator/related-tools.tsx
@@ -1,0 +1,82 @@
+import Link from "next/link";
+
+type ToolKey =
+  | "glass-morphism"
+  | "css-generator"
+  | "shadow-generator"
+  | "gradients";
+
+const TOOLS: {
+  key: ToolKey;
+  title: string;
+  href: string;
+  description: string;
+}[] = [
+  {
+    key: "glass-morphism",
+    title: "Glassmorphism Generator",
+    href: "/generator/glass-morphism",
+    description:
+      "Frosted-glass UI with blur, transparency, borders and gradients.",
+  },
+  {
+    key: "css-generator",
+    title: "CSS Gradient Generator",
+    href: "/generator/css-generator",
+    description:
+      "Linear, radial and conic gradients with live export to CSS & Tailwind.",
+  },
+  {
+    key: "shadow-generator",
+    title: "Shadow Generator",
+    href: "/generator/shadow-generator",
+    description:
+      "Layered box-shadows, elevation and neumorphism — copy CSS & Tailwind.",
+  },
+  {
+    key: "gradients",
+    title: "Gradient Gallery",
+    href: "/gradients",
+    description: "Free 4K gradient backgrounds to copy as CSS or download.",
+  },
+];
+
+/**
+ * RelatedTools — contextual in-content cross-links between the free generators.
+ * Universal component (no "use client"): renders in both server and client
+ * page trees so the links are present in the server-rendered HTML for SEO.
+ */
+export function RelatedTools({ current }: { current: ToolKey }) {
+  const others = TOOLS.filter((tool) => tool.key !== current);
+
+  return (
+    <section
+      aria-labelledby="related-tools-heading"
+      className="mx-auto w-full max-w-7xl px-4 py-12 md:px-6 md:py-16"
+    >
+      <h2
+        id="related-tools-heading"
+        className="text-2xl font-bold tracking-tight sm:text-3xl"
+      >
+        Related tools
+      </h2>
+      <p className="mt-2 text-muted-foreground">
+        More free CSS &amp; Tailwind generators from Ruixen UI.
+      </p>
+      <div className="mt-6 grid gap-4 sm:grid-cols-3">
+        {others.map((tool) => (
+          <Link
+            key={tool.key}
+            href={tool.href}
+            className="group rounded-xl border border-border p-5 transition-colors hover:bg-accent"
+          >
+            <div className="font-semibold text-foreground">{tool.title}</div>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {tool.description}
+            </p>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -302,6 +302,9 @@ const resourceColumns: FooterColumn[] = [
     heading: "Tools",
     links: [
       { label: "All Tools", href: "/tools" },
+      { label: "Glassmorphism Generator", href: "/generator/glass-morphism" },
+      { label: "CSS Gradient Generator", href: "/generator/css-generator" },
+      { label: "Shadow Generator", href: "/generator/shadow-generator" },
       { label: "Gradient Gallery", href: "/gradients" },
       { label: "Extrude", href: "/tools/extrude" },
       { label: "Blog", href: "/blog" },


### PR DESCRIPTION
## Why
Generators are the site's single biggest organic entry point (~60% of all GSC impressions from 5 pages), but they were under-optimized and a dead end — no path to the component library or Pro. This squeezes more from existing impressions and bridges tool visitors to the product.

## Changes
**Titles / CTR**
- Fix doubled-brand + truncation on glass & shadow titles; drop stale "(2025)"
- Add missing metadata to css-generator & gradients (they were showing the generic homepage title in SERP) via sibling `layout.tsx` (pages are client components)
- Lead the shadow title with the exact ranking query `tailwind shadow generator` (pos 3.8, 1.3% CTR)

**Indexability**
- Repoint dead canonicals (`www.ruixen.com/tools/glass` / `/tools/shadow` → real `/generator/*` URLs)
- Add the 4 generator/gradient pages to `sitemap.ts` (priority 0.8) — they were missing

**Internal linking (de-orphan)**
- Add generators to footer Tools column with keyword anchors
- New `RelatedTools` cross-link block on all 4 pages

**Tool → product funnel**
- New tracked `GeneratorCta` (component library primary, Pro secondary) between tool and related-tools; fires `cta_click` + `oss_pro_cta_clicked` with a `generator_<tool>` surface for per-tool funnel measurement

## Notes
- Typecheck clean
- No behavior change to the tools themselves
- Impact is gated on deploy + GSC re-index