### PR TITLE
Add explicit type annotation to octokit constant

### DIFF
--- a/lib/octokit.ts
+++ b/lib/octokit.ts
@@ -1,5 +1,5 @@
 import { Octokit } from "octokit";
 
-export const octokit = new Octokit({
+export const octokit: Octokit = new Octokit({
   auth: process.env.GITHUB_ACCESS_TOKEN,
 });


### PR DESCRIPTION
## Problem Background
The exported `octokit` constant in `lib/octokit.ts` relied on TypeScript type inference without an explicit annotation. While inference works, adding an explicit type can improve readability and maintainability, especially in complex contexts or when multiple developers collaborate on the codebase.

## Modification Details
This PR adds an explicit `: Octokit` type annotation to the `octokit` constant. The change is minimal and only affects the declaration line in `lib/octokit.ts`, ensuring no impact on runtime behavior or API signatures. This aligns with TypeScript best practices for clarity.

## Verification
To verify this change:
1. Run `tsc` (TypeScript compiler) to ensure no type errors are introduced.
2. Confirm that the `octokit` constant remains correctly typed in IDEs or via static analysis tools.
3. No functional tests should be affected, as this is purely a type annotation enhancement.