### PR TITLE
fix(analytics): restore PostHog tracking + SEO tier-1 generator funnel

### DIFF
--- a/app/(generator)/generator/css-generator/layout.tsx
+++ b/app/(generator)/generator/css-generator/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 
+import { ToolJsonLd } from "@/components/generator/tool-json-ld";
+
 export const metadata: Metadata = {
   title: "CSS Gradient Generator — Copy CSS & Tailwind",
   description:
@@ -26,5 +28,14 @@ export const metadata: Metadata = {
 };
 
 export default function Layout({ children }: { children: ReactNode }) {
-  return children;
+  return (
+    <>
+      <ToolJsonLd
+        name="CSS Gradient Generator"
+        description="Free in-browser CSS gradient generator — build linear, radial and conic gradients with drag-and-drop color stops and copy ready-to-use CSS & Tailwind."
+        path="/generator/css-generator"
+      />
+      {children}
+    </>
+  );
 }

--- a/app/(generator)/generator/glass-morphism/page.tsx
+++ b/app/(generator)/generator/glass-morphism/page.tsx
@@ -2,6 +2,7 @@
 import GlassGeneratorPage from "@/components/generator/glass/glass-generator-page";
 import { GeneratorCta } from "@/components/generator/generator-cta";
 import { RelatedTools } from "@/components/generator/related-tools";
+import { ToolJsonLd } from "@/components/generator/tool-json-ld";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -32,6 +33,11 @@ export const metadata: Metadata = {
 export default function Page() {
   return (
     <>
+      <ToolJsonLd
+        name="Glassmorphism Generator"
+        description="Free in-browser glassmorphism generator — tune blur, transparency, borders and gradients with a live preview and copy production-ready CSS & Tailwind."
+        path="/generator/glass-morphism"
+      />
       <GlassGeneratorPage />
       <GeneratorCta tool="glass-morphism" />
       <RelatedTools current="glass-morphism" />

--- a/app/(generator)/generator/shadow-generator/page.tsx
+++ b/app/(generator)/generator/shadow-generator/page.tsx
@@ -1,6 +1,7 @@
 import ShadowGeneratorPage from "@/components/generator/shadow/shadow-generator-page";
 import { GeneratorCta } from "@/components/generator/generator-cta";
 import { RelatedTools } from "@/components/generator/related-tools";
+import { ToolJsonLd } from "@/components/generator/tool-json-ld";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -31,6 +32,11 @@ export const metadata: Metadata = {
 export default function Page() {
   return (
     <>
+      <ToolJsonLd
+        name="Tailwind Shadow Generator"
+        description="Free CSS box-shadow generator — build soft, layered, inset and neumorphic shadows with a live preview and copy CSS & Tailwind instantly."
+        path="/generator/shadow-generator"
+      />
       <ShadowGeneratorPage />
       <GeneratorCta tool="shadow-generator" />
       <RelatedTools current="shadow-generator" />

--- a/app/(gradients)/gradients/layout.tsx
+++ b/app/(gradients)/gradients/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 
+import { ToolJsonLd } from "@/components/generator/tool-json-ld";
+
 export const metadata: Metadata = {
   title: "UI Gradients — Free 4K Gradient Backgrounds",
   description:
@@ -25,5 +27,14 @@ export const metadata: Metadata = {
 };
 
 export default function Layout({ children }: { children: ReactNode }) {
-  return children;
+  return (
+    <>
+      <ToolJsonLd
+        name="UI Gradients"
+        description="Free 4K gradient backgrounds for UIs, hero sections and wallpapers — copy the CSS or download the PNG in one click."
+        path="/gradients"
+      />
+      {children}
+    </>
+  );
 }

--- a/app/(gradients)/gradients/page.tsx
+++ b/app/(gradients)/gradients/page.tsx
@@ -102,11 +102,12 @@ export default function GradientsPage() {
         <div className="container mx-auto px-4 py-16 md:py-24">
           <div className="max-w-3xl">
             <h1 className="text-4xl md:text-6xl font-bold tracking-tight mb-6">
-              Gradient Collection
+              UI Gradients — Free 4K Backgrounds
             </h1>
             <p className="text-lg md:text-xl text-muted-foreground">
-              A curated collection of beautiful gradients for your next project.
-              Free to download and use in your designs.
+              A curated collection of free UI gradient backgrounds for hero
+              sections, cards and wallpapers. Copy the CSS or download the 4K
+              PNG — free to use in any project.
             </p>
           </div>
         </div>

--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -6,6 +6,7 @@ import WallOfLove from "@/components/sections/wall-of-love";
 import VideoShowcaseGrid from "@/components/sections/video-showcase-grid";
 import InspirationsSection from "@/components/sections/inspirations-section";
 import { ProSection } from "@/components/sections/pro-section";
+import { FreeTools } from "@/components/sections/free-tools";
 import { siteConfig } from "@/config/site";
 
 export default function Home() {
@@ -86,6 +87,7 @@ export default function Home() {
       <ComponentCategories />
       {/* <VideoShowcaseGrid /> */}
       {/* <InspirationsSection /> */}
+      <FreeTools />
       <WallOfLove />
       <ProSection />
       <FAQSection faqItems={faqItems} className="py-16 md:py-24" />

--- a/app/preview/layout.tsx
+++ b/app/preview/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+// Preview routes render the exact same components already documented under
+// /docs/components/*, so to Google they are duplicate content with no
+// standalone search value (31 such pages, 0 clicks across 90 days of GSC).
+// Mark the whole /preview/* route group `noindex` so Google drops the URLs
+// it already has and crawl budget flows to real pages instead.
+//
+// We deliberately keep `follow: true` (so internal-link equity still flows
+// out of these pages) and do NOT add /preview to robots.txt — Google must be
+// able to crawl the page to SEE this noindex and de-index the existing URLs.
+// A robots.txt disallow would freeze them in the index as URL-only entries.
+export const metadata: Metadata = {
+  robots: { index: false, follow: true },
+};
+
+export default function PreviewLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -36,6 +36,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.9,
     },
     {
+      url: `${protocol}://${domain}/tools`,
+      lastModified: new Date(),
+      priority: 0.8,
+    },
+    {
       url: `${protocol}://${domain}/tools/tw-v3-to-v4`,
       lastModified: new Date(),
       priority: 0.8,

--- a/components/generator/tool-json-ld.tsx
+++ b/components/generator/tool-json-ld.tsx
@@ -1,0 +1,44 @@
+import { siteConfig } from "@/config/site";
+
+interface ToolJsonLdProps {
+  /** Tool display name, e.g. "Glassmorphism Generator". */
+  name: string;
+  /** One-line description used for the rich-result snippet. */
+  description: string;
+  /** Path beginning with a slash, e.g. "/generator/glass-morphism". */
+  path: string;
+}
+
+/**
+ * SoftwareApplication JSON-LD for the free generator tools. Declaring each
+ * tool as a free SoftwareApplication makes the page eligible for richer
+ * search results (app/price chips), which lifts CTR on pages that already
+ * rank — the proven bottleneck for Ruixen's tool pages (high impressions,
+ * ~1% CTR). Server component, so it can be rendered either from a server
+ * page (glass, shadow) or from a layout that wraps a "use client" page
+ * (css-generator, gradients).
+ */
+export function ToolJsonLd({ name, description, path }: ToolJsonLdProps) {
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name,
+    applicationCategory: "DeveloperApplication",
+    operatingSystem: "All",
+    description,
+    url: `${siteConfig.url}${path}`,
+    offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+    publisher: {
+      "@type": "Organization",
+      name: "Ruixen UI",
+      url: siteConfig.url,
+    },
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+    />
+  );
+}

--- a/components/posthog-provider.tsx
+++ b/components/posthog-provider.tsx
@@ -9,7 +9,20 @@ import { PostHogProvider } from "posthog-js/react";
 // events into the production PostHog project. Mirrors the pro.ruixen.com
 // pattern at components/posthog-provider.tsx.
 const isProduction = process.env.NODE_ENV === "production";
-const hasApiKey = Boolean(process.env.NEXT_PUBLIC_POSTHOG_API_KEY);
+
+// PostHog project key. `phc_` keys are PUBLIC by design — PostHog ships them
+// in the client bundle of every instrumented site (pro.ruixen.com already
+// exposes this exact key), so a hard fallback leaks nothing. This exists
+// because ruixen.com analytics silently died for ~6 weeks (Apr 22 → Jun 2026):
+// `.env` is gitignored, the production build env was missing
+// NEXT_PUBLIC_POSTHOG_API_KEY, so `hasApiKey` was false and posthog.init()
+// never ran. The fallback makes ingestion resilient to env/deploy
+// misconfiguration on any host (Vercel or the VPS Docker build). The env var
+// still overrides it for other deployments/projects.
+const POSTHOG_KEY =
+  process.env.NEXT_PUBLIC_POSTHOG_API_KEY ||
+  "phc_lL6RqVBsJG75nnpYsu0208iEr2IRcCq8zi5NgQY6lj2";
+const hasApiKey = Boolean(POSTHOG_KEY);
 
 // `cross_subdomain_cookie: true` with `localStorage+cookie` persistence
 // writes the anonymous distinct_id into a `.ruixen.com` domain cookie so
@@ -26,7 +39,7 @@ if (typeof window !== "undefined" && isProduction && hasApiKey) {
   const envHostIsDirectCloud = !!envHost?.match(/\.i\.posthog\.com/);
   const apiHost = !envHost || envHostIsDirectCloud ? "/ingest" : envHost;
 
-  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_API_KEY!, {
+  posthog.init(POSTHOG_KEY, {
     api_host: apiHost,
     ui_host: "https://us.posthog.com",
     capture_pageview: false, // We capture manually below

--- a/components/sections/free-tools.tsx
+++ b/components/sections/free-tools.tsx
@@ -1,0 +1,74 @@
+import Link from "next/link";
+
+/**
+ * FreeTools — homepage section linking to the free generator tools.
+ *
+ * The homepage is the site's highest-authority page, yet it previously
+ * linked to none of the tools. Tools are Ruixen's only proven organic
+ * channel (≈60% of all search impressions), but they sit on page 2.
+ * These contextual, keyword-anchored links pass homepage equity straight
+ * to the tool pages to help push them onto page 1 — and give crawlers a
+ * first-class path to them.
+ */
+const TOOLS: { title: string; href: string; description: string }[] = [
+  {
+    title: "Glassmorphism Generator",
+    href: "/generator/glass-morphism",
+    description:
+      "Frosted-glass UI — tune blur, transparency, borders and gradients, then copy CSS or Tailwind.",
+  },
+  {
+    title: "CSS Gradient Generator",
+    href: "/generator/css-generator",
+    description:
+      "Linear, radial and conic gradients with stop-level control and one-click CSS & Tailwind export.",
+  },
+  {
+    title: "Tailwind Shadow Generator",
+    href: "/generator/shadow-generator",
+    description:
+      "Layered box-shadows, elevation and neumorphism — copy as CSS or Tailwind in a click.",
+  },
+  {
+    title: "UI Gradients",
+    href: "/gradients",
+    description:
+      "Free 4K gradient backgrounds for heroes and cards — copy the CSS or download the PNG.",
+  },
+];
+
+export function FreeTools() {
+  return (
+    <section className="w-full py-16 md:py-24">
+      <div className="mx-auto max-w-6xl px-4">
+        <div className="max-w-2xl">
+          <p className="text-sm uppercase tracking-[0.15em] text-foreground/30 mb-4">
+            Free tools — no signup
+          </p>
+          <h2 className="text-2xl sm:text-3xl md:text-4xl font-semibold tracking-tight text-foreground">
+            Free CSS &amp; Tailwind generators
+          </h2>
+          <p className="mt-4 text-foreground/50 text-base leading-relaxed">
+            Design glassmorphism, gradients and shadows in the browser and copy
+            production-ready CSS or Tailwind — no account, no install.
+          </p>
+        </div>
+
+        <div className="mt-8 grid gap-4 sm:grid-cols-2">
+          {TOOLS.map((tool) => (
+            <Link
+              key={tool.href}
+              href={tool.href}
+              className="group rounded-xl border border-border p-5 transition-colors hover:bg-accent"
+            >
+              <div className="font-semibold text-foreground">{tool.title}</div>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {tool.description}
+              </p>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Why
ruixen.com PostHog tracking has been **dead since ~Apr 22** (0 events in June; pro.ruixen.com unaffected). Root cause: `.env` is gitignored, so the build depends on the platform env (Vercel settings / Docker build-arg), and `NEXT_PUBLIC_POSTHOG_API_KEY` was missing → `hasApiKey=false` → `posthog.init()` never ran → the `phc_` key isn't even in the live bundle. The `/ingest` proxy itself works fine (verified). We've been blind on the main site for ~6 weeks (GA4 shows ~13k pageviews / ~5–6k MAU in May — real traction we couldn't see).

## Changes
**fix(analytics):** hard fallback to the public PostHog project key in `posthog-provider.tsx`. `phc_` keys are public by design (shipped in every client bundle), so this leaks nothing and makes ingestion resilient to env/deploy misconfiguration on Vercel **or** the VPS Docker build. `isProduction` still gates local dev out of prod analytics.

**feat(seo) — tier 1 generator funnel:**
- `SoftwareApplication` JSON-LD on glass/shadow/css/gradients (rich-result eligibility = CTR lever on pages that already rank)
- `FreeTools` homepage section linking the 4 tools with keyword anchors (homepage linked to none before)
- `noindex /preview/*` (31 duplicate pages, 0 GSC clicks)
- `/tools` hub added to sitemap (was missing)
- gradients H1 now contains the target keyword

## Verification
`tsc --noEmit` clean on all touched files. Tracking fix takes effect on the next ruixen.com deploy.